### PR TITLE
feat: add test infrastructure and unit tests (Step 7)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,11 @@
 common-utils = "0.9.23"
 
 aboutlibraries = "14.2.0"
+coroutines = "1.9.0"
+kover = "0.9.1"
+mockk = "1.13.17"
+truth = "1.4.4"
+turbine = "1.2.0"
 hilt = "2.59.2"
 ksp = "2.3.8"
 # activity-compose 1.13.x requires androidx.core.app.PictureInPictureProvider, absent in the androidx.core
@@ -40,6 +45,10 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+truth = { module = "com.google.truth:truth", version.ref = "truth" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
 oneui-design = { module = "io.github.tribalfs:oneui-design", version.ref = "oneui-design" }
 oneui-icons = { module = "io.github.oneuiproject:icons", version.ref = "oneui-icons" }
@@ -48,6 +57,7 @@ review = { module = "com.google.android.play:review", version.ref = "review" }
 [plugins]
 android-library = { id = "com.android.library", version.ref = "gradle" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,11 @@
 common-utils = "0.9.23"
 
 aboutlibraries = "14.2.0"
-coroutines = "1.9.0"
-kover = "0.9.1"
-mockk = "1.13.17"
-truth = "1.4.4"
-turbine = "1.2.0"
+coroutines = "1.11.0"
+kover = "0.9.8"
+mockk = "1.14.9"
+truth = "1.4.5"
+turbine = "1.2.1"
 hilt = "2.59.2"
 ksp = "2.3.8"
 # activity-compose 1.13.x requires androidx.core.app.PictureInPictureProvider, absent in the androidx.core

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.dependency.analysis)
     alias(libs.plugins.detekt)
     alias(libs.plugins.spotless)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -92,4 +93,28 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "*.databinding.*",
+                    "*.BuildConfig",
+                    "*Hilt_*",
+                    "*_HiltModules*",
+                    "*_Factory",
+                    "*_MembersInjector",
+                    "dagger.hilt.*",
+                    "hilt_aggregated_deps.*",
+                    "de.lemke.commonutils.di.*",
+                )
+            }
+        }
+    }
 }

--- a/lib/src/test/java/de/lemke/commonutils/BasicUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/BasicUtilsTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import android.os.Bundle
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BasicUtilsTest {
+    // region saveSearchAndActionMode
+
+    @Test
+    fun `saveSearchAndActionMode stores search mode flag when true`() {
+        val bundle = mockk<Bundle>(relaxed = true)
+        bundle.saveSearchAndActionMode(isSearchMode = true)
+        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, true) }
+    }
+
+    @Test
+    fun `saveSearchAndActionMode omits search mode flag when false`() {
+        val bundle = mockk<Bundle>(relaxed = true)
+        bundle.saveSearchAndActionMode(isSearchMode = false)
+        verify(exactly = 0) { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, any()) }
+    }
+
+    @Test
+    fun `saveSearchAndActionMode stores action mode flag and IDs when true`() {
+        val bundle = mockk<Bundle>(relaxed = true)
+        val ids = setOf(1L, 2L, 3L)
+        bundle.saveSearchAndActionMode(isActionMode = true, selectedIds = ids)
+        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
+        verify { bundle.putLongArray(COMMONUTILS_KEY_SELECTED_IDS, ids.toLongArray()) }
+    }
+
+    @Test
+    fun `saveSearchAndActionMode omits action mode data when false`() {
+        val bundle = mockk<Bundle>(relaxed = true)
+        bundle.saveSearchAndActionMode(isActionMode = false)
+        verify(exactly = 0) { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, any()) }
+        verify(exactly = 0) { bundle.putLongArray(any(), any()) }
+    }
+
+    @Test
+    fun `saveSearchAndActionMode stores both modes simultaneously`() {
+        val bundle = mockk<Bundle>(relaxed = true)
+        bundle.saveSearchAndActionMode(isSearchMode = true, isActionMode = true, selectedIds = setOf(42L))
+        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, true) }
+        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
+    }
+
+    // endregion
+
+    // region restoreSearchAndActionMode
+
+    @Test
+    fun `restoreSearchAndActionMode calls onSearchMode when flag set`() {
+        val bundle = mockk<Bundle>()
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns true
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns false
+
+        var called = false
+        bundle.restoreSearchAndActionMode(onSearchMode = { called = true })
+        assertTrue(called)
+    }
+
+    @Test
+    fun `restoreSearchAndActionMode skips onSearchMode when flag not set`() {
+        val bundle = mockk<Bundle>()
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns false
+
+        var called = false
+        bundle.restoreSearchAndActionMode(onSearchMode = { called = true })
+        assertFalse(called)
+    }
+
+    @Test
+    fun `restoreSearchAndActionMode calls onActionMode with IDs`() {
+        val bundle = mockk<Bundle>()
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns true
+        every { bundle.getLongArray(COMMONUTILS_KEY_SELECTED_IDS) } returns longArrayOf(10L, 20L)
+
+        var receivedIds: Set<Long>? = null
+        bundle.restoreSearchAndActionMode(onActionMode = { receivedIds = it })
+        assertEquals(setOf(10L, 20L), receivedIds)
+    }
+
+    @Test
+    fun `restoreSearchAndActionMode passes empty set when getLongArray returns null`() {
+        val bundle = mockk<Bundle>()
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
+        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns true
+        every { bundle.getLongArray(COMMONUTILS_KEY_SELECTED_IDS) } returns null
+
+        var receivedIds: Set<Long>? = null
+        bundle.restoreSearchAndActionMode(onActionMode = { receivedIds = it })
+        assertEquals(emptySet<Long>(), receivedIds)
+    }
+
+    @Test
+    fun `restoreSearchAndActionMode calls bundleIsNull when receiver is null`() {
+        var called = false
+        val bundle: Bundle? = null
+        bundle.restoreSearchAndActionMode(bundleIsNull = { called = true })
+        assertTrue(called)
+    }
+
+    // endregion
+}

--- a/lib/src/test/java/de/lemke/commonutils/BasicUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/BasicUtilsTest.kt
@@ -47,7 +47,7 @@ class BasicUtilsTest {
         val ids = setOf(1L, 2L, 3L)
         bundle.saveSearchAndActionMode(isActionMode = true, selectedIds = ids)
         verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
-        verify { bundle.putLongArray(COMMONUTILS_KEY_SELECTED_IDS, ids.toLongArray()) }
+        verify { bundle.putLongArray(COMMONUTILS_KEY_SELECTED_IDS, match { it.contentEquals(ids.toLongArray()) }) }
     }
 
     @Test

--- a/lib/src/test/java/de/lemke/commonutils/MainDispatcherExtension.kt
+++ b/lib/src/test/java/de/lemke/commonutils/MainDispatcherExtension.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package de.lemke.commonutils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class MainDispatcherExtension(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : BeforeEachCallback, AfterEachCallback {
+    override fun beforeEach(context: ExtensionContext) = Dispatchers.setMain(testDispatcher)
+
+    override fun afterEach(context: ExtensionContext) = Dispatchers.resetMain()
+}

--- a/lib/src/test/java/de/lemke/commonutils/di/CoroutineDispatchersModuleTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/di/CoroutineDispatchersModuleTest.kt
@@ -13,27 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(ExperimentalCoroutinesApi::class)
-
 package de.lemke.commonutils.di
 
+import de.lemke.commonutils.MainDispatcherExtension
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(MainDispatcherExtension::class)
 class CoroutineDispatchersModuleTest {
-    @BeforeEach
-    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
-
-    @AfterEach
-    fun tearDown() = Dispatchers.resetMain()
-
     @Test
     fun `provideIo returns Dispatchers IO`() {
         assertSame(Dispatchers.IO, CoroutineDispatchersModule.provideIo())

--- a/lib/src/test/java/de/lemke/commonutils/di/CoroutineDispatchersModuleTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/di/CoroutineDispatchersModuleTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package de.lemke.commonutils.di
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CoroutineDispatchersModuleTest {
+    @BeforeEach
+    fun setUp() = Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    @AfterEach
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `provideIo returns Dispatchers IO`() {
+        assertSame(Dispatchers.IO, CoroutineDispatchersModule.provideIo())
+    }
+
+    @Test
+    fun `provideDefault returns Dispatchers Default`() {
+        assertSame(Dispatchers.Default, CoroutineDispatchersModule.provideDefault())
+    }
+
+    @Test
+    fun `provideMain returns Dispatchers Main`() {
+        assertSame(Dispatchers.Main, CoroutineDispatchersModule.provideMain())
+    }
+}


### PR DESCRIPTION
## Summary

- Adds test dependencies to `libs.versions.toml`: MockK, Turbine, Truth, `kotlinx-coroutines-test`, Kover plugin
- Wires Kover into `lib/build.gradle.kts` with generated-code exclusions (databinding, BuildConfig, Hilt internals)
- `MainDispatcherExtension` — JUnit5 `BeforeEach`/`AfterEach` extension that installs `UnconfinedTestDispatcher` as the main dispatcher for coroutines tests
- `BasicUtilsTest` — 10 tests covering `saveSearchAndActionMode` and `restoreSearchAndActionMode` Bundle round-trips via MockK (no Robolectric needed)
- `CoroutineDispatchersModuleTest` — verifies each `@Provides` method in `CoroutineDispatchersModule` maps to the correct `Dispatchers` constant

## Notes

- Lifecycle-bound tests (`collectState`/`collectEvents`, `launchAndRepeatWithLifecycle`) are deferred to Step 8 where Robolectric is added — they require an `AppCompatActivity`/`Fragment` with a controllable lifecycle
- Kover report: `./gradlew :lib:koverHtmlReport` → `lib/build/reports/kover/html/index.html`

## Test plan

- [x] `./gradlew spotlessCheck detekt testDebugUnitTest assembleRelease` — all green
- [x] `./gradlew :lib:koverHtmlReport` — report generates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for utility functions including save/restore operations, dispatcher behavior, and coroutine module functionality.
  * Introduced test utilities for improved test reliability.

* **Chores**
  * Updated testing and code quality dependencies to latest versions.
  * Added code coverage tracking configuration with exclusion filters for generated code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lemkinator/common-utils/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->