### PR TITLE
chore: add Renovate groupings and version policy (Step 11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,13 @@ Document any pin or downgrade with a `# Why pinned:` comment in
 
 ## Hilt (same-module)
 
-Hilt is added as a same-module dep — qualifiers and `CoroutineDispatchersModule`
-ship in the published artifact. Every consuming app already uses Hilt,
-so transitive `api` exposure is intentional. A separate `:lib-di` subproject
-would let consumers opt out but adds a publish target for zero practical gain.
+Hilt is added as a same-module `implementation` dep — qualifiers and
+`CoroutineDispatchersModule` ship compiled into the published AAR.
+Consumers see `@IoDispatcher` / `@DefaultDispatcher` / `@MainDispatcher`
+because those annotation classes live in our AAR, not in Hilt's runtime jar,
+so no transitive exposure is needed. Every consuming app already declares
+Hilt directly. A separate `:lib-di` subproject would let consumers opt out
+but adds a publish target for zero practical gain.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,37 @@ bundled dependencies — be careful when adding new dependencies.
 Hilt can inject them directly; the module installs into
 `SingletonComponent`.
 
+## Version Policy
+
+**Default: use the latest stable version of every dependency.**
+Renovate keeps minor/patch updates current; bump majors manually
+with release-note review.
+
+Document any pin or downgrade with a `# Why pinned:` comment in
+`libs.versions.toml`. Known exception classes:
+
+1. **Kotlin + KSP lockstep** — KSP minor must match Kotlin minor
+   (e.g. Kotlin `2.3.21` requires KSP `2.3.x`). Renovate's `kotlin`
+   group enforces this.
+2. **Static-analysis on fresh Kotlin majors** — Detekt typically
+   lags new Kotlin releases by 1–3 months. Stay on the latest
+   pre-release/alpha that supports your Kotlin version until a stable
+   one lands. The `static-analysis` Renovate group bumps them together.
+3. **Plugin AGP compatibility windows** — check plugin docs before
+   bumping AGP.
+4. **`oneui-design`** — versioned against OneUI major releases
+   (e.g. `0.9.10+oneui8`); review manually per bump.
+5. **Hilt version** — must match consumer apps to avoid
+   duplicate-class errors. Renovate's `hilt` group bumps both repos
+   together.
+
+## Hilt (same-module)
+
+Hilt is added as a same-module dep — qualifiers and `CoroutineDispatchersModule`
+ship in the published artifact. Every consuming app already uses Hilt,
+so transitive `api` exposure is intentional. A separate `:lib-di` subproject
+would let consumers opt out but adds a publish target for zero practical gain.
+
 ## Configuration
 
 - Version catalog: `gradle/libs.versions.toml`

--- a/renovate.json
+++ b/renovate.json
@@ -8,13 +8,76 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest"
-      ],
+      "matchUpdateTypes": ["patch", "digest"],
       "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "automergeType": "branch",
+      "platformAutomerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "matchCurrentVersion": "!/^0/",
+      "matchPackageNames": [
+        "com.google.truth:truth",
+        "io.mockk:**",
+        "app.cash.turbine:**",
+        "com.google.dagger:**",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+      ],
       "automerge": true
+    },
+    {
+      "groupName": "kotlin",
+      "matchPackageNames": [
+        "org.jetbrains.kotlin:**",
+        "org.jetbrains.kotlin.android",
+        "com.google.devtools.ksp**"
+      ]
+    },
+    {
+      "groupName": "hilt",
+      "matchPackageNames": [
+        "com.google.dagger:**",
+        "com.google.dagger.hilt.android"
+      ]
+    },
+    {
+      "groupName": "androidx-test",
+      "matchPackageNames": [
+        "androidx.test:**",
+        "androidx.test.ext:**",
+        "androidx.test.espresso:**"
+      ]
+    },
+    {
+      "groupName": "junit5",
+      "matchPackageNames": [
+        "org.junit:junit-bom",
+        "org.junit.jupiter:**",
+        "de.mannodermaus.android-junit"
+      ]
+    },
+    {
+      "groupName": "robolectric",
+      "matchPackageNames": [
+        "org.robolectric:**"
+      ]
+    },
+    {
+      "groupName": "static-analysis",
+      "matchPackageNames": [
+        "dev.detekt:**",
+        "io.gitlab.arturbosch.detekt**",
+        "com.diffplug.spotless"
+      ]
+    },
+    {
+      "groupName": "oneui-design",
+      "matchPackageNames": [
+        "io.github.tribalfs:oneui-design",
+        "io.github.tribalfs:oneui-icons"
+      ],
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,8 @@
       "matchPackageNames": [
         "org.junit:junit-bom",
         "org.junit.jupiter:**",
+        "org.junit.platform:**",
+        "org.junit.vintage:**",
         "de.mannodermaus.android-junit"
       ]
     },
@@ -75,7 +77,7 @@
       "groupName": "oneui-design",
       "matchPackageNames": [
         "io.github.tribalfs:oneui-design",
-        "io.github.tribalfs:oneui-icons"
+        "io.github.oneuiproject:icons"
       ],
       "automerge": false
     }


### PR DESCRIPTION
## Summary

- Renovate: groups `kotlin`/`hilt`/`junit5`/`robolectric`/`static-analysis`/`oneui-design` for coordinated bumps
- Patch+digest automerge via branch (platformAutomerge); minor automerge for test/DI deps
- `oneui-design` group set non-automerge (manual review required per OneUI major)
- `CLAUDE.md`: adds version policy + Hilt same-module decision rationale

## Test plan

- [ ] CI passes (no build changes)
- [ ] Renovate dashboard shows expected groups on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed version policy documentation specifying dependency update defaults, automerge behavior patterns, and explicit handling guidelines for critical dependencies like Kotlin, Hilt, and testing frameworks.

* **Chores**
  * Refined automated dependency update behavior with selective automerge policies and granular merge rules organized by dependency groups to improve build stability and version control consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lemkinator/common-utils/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->