### PR TITLE
docs: add KDoc to all public API symbols (Step 12)

### DIFF
--- a/.idea/ktlint-plugin.xml
+++ b/.idea/ktlint-plugin.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.nbadal.ktlint.KtlintProjectSettings">
+    <ktlintMode>DISTRACT_FREE</ktlintMode>
+    <ktlintRulesetVersion>DEFAULT</ktlintRulesetVersion>
+  </component>
+</project>

--- a/lib/src/main/java/de/lemke/commonutils/ActivityUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ActivityUtils.kt
@@ -27,6 +27,7 @@ import de.lemke.commonutils.ui.activity.CommonUtilsSettingsActivity
 
 private const val TAG = "ActivityUtils"
 
+/** Configures the OOBE activity to launch [nextActivity] on completion. */
 fun setupCommonUtilsOOBEActivity(
     setAcceptedTosVersion: Boolean? = null,
     nextActivity: Class<*>,
@@ -35,6 +36,7 @@ fun setupCommonUtilsOOBEActivity(
     CommonUtilsOOBEActivity.nextActivity = nextActivity
 }
 
+/** Configures the OOBE activity to invoke [onContinue] when the user proceeds. */
 fun setupCommonUtilsOOBEActivity(
     setAcceptedTosVersion: Boolean? = null,
     onContinue: (() -> Unit),
@@ -43,6 +45,7 @@ fun setupCommonUtilsOOBEActivity(
     CommonUtilsOOBEActivity.onContinue = onContinue
 }
 
+/** Configures the settings activity with the given preference XML resources and optional init block. */
 fun setupCommonUtilsSettingsActivity(
     vararg preferences: Int,
     initPreferences: suspend PreferenceFragmentCompat.() -> Unit = {},
@@ -51,6 +54,7 @@ fun setupCommonUtilsSettingsActivity(
     CommonUtilsSettingsActivity.initPreferences = initPreferences
 }
 
+/** Configures the settings activity with the given preference XML resource list and optional init block. */
 fun setupCommonUtilsSettingsActivity(
     preferences: List<Int>,
     initPreferences: suspend PreferenceFragmentCompat.() -> Unit = {},
@@ -59,12 +63,14 @@ fun setupCommonUtilsSettingsActivity(
     CommonUtilsSettingsActivity.initPreferences = initPreferences
 }
 
+/** Configures the About Me activity with an optional share-app callback. */
 fun setupCommonUtilsAboutMeActivity(onShareApp: (activity: Activity) -> Unit = {}) {
     CommonUtilsAboutMeActivity.apply {
         this.onShareApp = onShareApp
     }
 }
 
+/** Configures the About activity with a static version string and optional extra text. */
 fun setupCommonUtilsAboutActivity(
     appVersion: String,
     optionalText: SpannableString? = null,
@@ -75,6 +81,7 @@ fun setupCommonUtilsAboutActivity(
     }
 }
 
+/** Configures the About activity with a suspend function that resolves the version string at display time. */
 fun setupCommonUtilsAboutActivity(getAppVersion: suspend () -> String) {
     CommonUtilsAboutActivity.getAppVersion = getAppVersion
 }

--- a/lib/src/main/java/de/lemke/commonutils/ActivityUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ActivityUtils.kt
@@ -81,7 +81,13 @@ fun setupCommonUtilsAboutActivity(
     }
 }
 
-/** Configures the About activity with a suspend function that resolves the version string at display time. */
-fun setupCommonUtilsAboutActivity(getAppVersion: suspend () -> String) {
-    CommonUtilsAboutActivity.getAppVersion = getAppVersion
+/** Configures the About activity with a suspend function that resolves the version string at display time and optional extra text. */
+fun setupCommonUtilsAboutActivity(
+    getAppVersion: suspend () -> String,
+    optionalText: SpannableString? = null,
+) {
+    CommonUtilsAboutActivity.apply {
+        this.getAppVersion = getAppVersion
+        this.optionalText = optionalText
+    }
 }

--- a/lib/src/main/java/de/lemke/commonutils/AppUpdateManagerUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/AppUpdateManagerUtils.kt
@@ -25,6 +25,7 @@ import com.google.android.play.core.install.model.UpdateAvailability.UPDATE_NOT_
 
 private const val TAG = "AppUpdateManagerUtils"
 
+/** Checks Play Store for an available update and invokes [action] if one exists. */
 fun Context.onAppUpdateAvailable(action: () -> Unit) {
     AppUpdateManagerFactory
         .create(this)

--- a/lib/src/main/java/de/lemke/commonutils/BasicUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/BasicUtils.kt
@@ -41,18 +41,23 @@ import dev.oneuiproject.oneui.design.R as designR
 private const val TAG = "BasicUtils"
 private const val DELETE_APP_DATA_DELAY_MS = 500L
 
+/** Shows a short toast with the given message. */
 fun Fragment.toast(msg: String) = requireContext().toast(msg)
 
+/** Shows a short toast with the given message. */
 fun Context.toast(msg: String) = Toast.makeText(this, msg, LENGTH_SHORT).show()
 
+/** Shows a short toast with the given string resource. */
 fun Fragment.toast(
     @StringRes stringResId: Int,
 ) = requireContext().toast(stringResId)
 
+/** Shows a short toast with the given string resource. */
 fun Context.toast(
     @StringRes stringResId: Int,
 ) = Toast.makeText(this, stringResId, LENGTH_SHORT).show()
 
+/** Launches [block] in the lifecycle scope, repeating it whenever the lifecycle reaches [minActiveState]. */
 inline fun AppCompatActivity.launchAndRepeatWithLifecycle(
     minActiveState: State = STARTED,
     crossinline block: suspend CoroutineScope.() -> Unit,
@@ -60,6 +65,7 @@ inline fun AppCompatActivity.launchAndRepeatWithLifecycle(
     lifecycleScope.launch { lifecycle.repeatOnLifecycle(minActiveState) { block() } }
 }
 
+/** Launches [block] in the view lifecycle scope, repeating it whenever the view lifecycle reaches [minActiveState]. */
 inline fun Fragment.launchAndRepeatWithViewLifecycle(
     minActiveState: State = STARTED,
     crossinline block: suspend CoroutineScope.() -> Unit,
@@ -67,6 +73,7 @@ inline fun Fragment.launchAndRepeatWithViewLifecycle(
     viewLifecycleOwner.lifecycleScope.launch { viewLifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) { block() } }
 }
 
+/** Shows a confirmation dialog and clears all application user data on confirmation. */
 fun Fragment.deleteAppDataAndExit(
     title: String? = null,
     message: String? = null,
@@ -93,10 +100,16 @@ fun Fragment.deleteAppDataAndExit(
     }
 }
 
+/** Bundle key for persisting search mode state. */
 const val COMMONUTILS_KEY_IS_SEARCH_MODE = "commonutils_isSearchMode"
+
+/** Bundle key for persisting action mode state. */
 const val COMMONUTILS_KEY_IS_ACTION_MODE = "commonutils_isActionMode"
+
+/** Bundle key for persisting the set of selected item IDs during action mode. */
 const val COMMONUTILS_KEY_SELECTED_IDS = "commonutils_selectedIds"
 
+/** Saves search and action mode state into this bundle for later restoration via [restoreSearchAndActionMode]. */
 fun Bundle.saveSearchAndActionMode(
     isSearchMode: Boolean = false,
     isActionMode: Boolean = false,
@@ -111,6 +124,7 @@ fun Bundle.saveSearchAndActionMode(
     }
 }
 
+/** Restores search and action mode state from this bundle, invoking the appropriate callback. */
 inline fun Bundle?.restoreSearchAndActionMode(
     crossinline onSearchMode: () -> Unit = {},
     crossinline onActionMode: (selectedIds: Set<Long>) -> Unit = {},

--- a/lib/src/main/java/de/lemke/commonutils/BasicUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/BasicUtils.kt
@@ -124,7 +124,7 @@ fun Bundle.saveSearchAndActionMode(
     }
 }
 
-/** Restores search and action mode state from this bundle, invoking the appropriate callback. */
+/** Restores search and action mode state from this bundle, invoking the provided callbacks as needed. */
 inline fun Bundle?.restoreSearchAndActionMode(
     crossinline onSearchMode: () -> Unit = {},
     crossinline onActionMode: (selectedIds: Set<Long>) -> Unit = {},

--- a/lib/src/main/java/de/lemke/commonutils/CheckAppStartUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/CheckAppStartUtils.kt
@@ -32,6 +32,7 @@ import de.lemke.commonutils.ui.activity.CommonUtilsOOBEActivity
 
 private const val TAG = "CheckAppStartUtils"
 
+/** Checks whether this is the first run, a version upgrade, or a normal start; persists version info for next launch. */
 fun AppCompatActivity.checkAppStart(
     versionCode: Int,
     versionName: String,
@@ -61,6 +62,11 @@ fun AppCompatActivity.checkAppStart(
     }
 }
 
+/**
+ * Checks the app start result and opens the OOBE activity if required.
+ *
+ * @return `true` if OOBE was opened and the current activity finished.
+ */
 fun AppCompatActivity.checkAppStartAndHandleOOBE(
     versionCode: Int,
     versionName: String,
@@ -73,6 +79,7 @@ fun AppCompatActivity.checkAppStartAndHandleOOBE(
     return false
 }
 
+/** Starts [CommonUtilsOOBEActivity] and finishes this activity with a fade transition. */
 fun AppCompatActivity.openOOBEAndFinish() {
     startActivity(Intent(applicationContext, CommonUtilsOOBEActivity::class.java))
     @Suppress("DEPRECATION")
@@ -80,8 +87,10 @@ fun AppCompatActivity.openOOBEAndFinish() {
     finishAfterTransition()
 }
 
+/** Result category of an app launch relative to the previously recorded version. */
 enum class AppStartResult { FIRST_TIME, FIRST_TIME_VERSION, NORMAL }
 
+/** Snapshot of version and TOS state captured at app launch. */
 class AppStart(
     val result: AppStartResult,
     val versionCode: Int,
@@ -91,11 +100,19 @@ class AppStart(
     val tosVersion: Int,
     val acceptedTosVersion: Int,
 ) {
+    /** `true` if no previous install was recorded. */
     val isFirstTime get() = lastVersionCode == -1
+
+    /** `true` if the app was upgraded since the last launch. */
     val isFirstTimeVersion get() = lastVersionCode < versionCode
+
+    /** `true` if the user has accepted the current TOS version. */
     val tosAccepted get() = acceptedTosVersion >= tosVersion
+
+    /** `true` if OOBE should be shown (first install or TOS not accepted). */
     val shouldShowOOBE get() = isFirstTime || !tosAccepted
 
+    /** `true` if [threshold] falls within the range of version codes updated across on this launch. */
     fun versionThresholdPassed(threshold: Int) = threshold in lastVersionCode..<versionCode
 
     override fun toString(): String =

--- a/lib/src/main/java/de/lemke/commonutils/DrawerUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/DrawerUtils.kt
@@ -30,6 +30,7 @@ import dev.oneuiproject.oneui.design.R as designR
 private const val TAG = "DrawerUtils"
 private const val NAV_RAIL_MIN_SIDE_MARGIN_DP = 14
 
+/** Sets up the drawer header button with an info icon navigating to [CommonUtilsAboutActivity] and configures the nav rail. */
 fun NavDrawerLayout.setupHeaderAndNavRail(aboutApp: String) {
     setupHeaderButton(
         icon = AppCompatResources.getDrawable(context, iconsR.drawable.ic_oui_info_outline)!!,
@@ -44,6 +45,7 @@ fun NavDrawerLayout.setupHeaderAndNavRail(aboutApp: String) {
     context.onAppUpdateAvailable { setButtonBadges(Badge.DOT, Badge.DOT) }
 }
 
+/** Wraps [listener] to ignore repeated clicks within [interval] milliseconds, preventing double-navigation. */
 fun DrawerNavigationView.onNavigationSingleClick(
     interval: Long = 600,
     listener: NavigationView.OnNavigationItemSelectedListener,

--- a/lib/src/main/java/de/lemke/commonutils/EmailUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/EmailUtils.kt
@@ -32,12 +32,14 @@ import androidx.fragment.app.Fragment
 
 private const val TAG = "EmailUtils"
 
+/** Opens a mail client to send an email to [email] with the given [subject] and [text]. */
 fun Context.sendEmail(
     email: String,
     subject: String,
     text: String,
 ): Boolean = sendEmail(arrayOf(email), subject, text)
 
+/** Opens a mail client to send an email to [emails] with the given [subject] and [text]. */
 fun Context.sendEmail(
     emails: Array<String>,
     subject: String,
@@ -59,16 +61,19 @@ fun Context.sendEmail(
         false
     }
 
+/** Sends a help request email with a pre-filled body. */
 fun Context.sendEmailHelp(
     email: String,
     subject: String,
 ) = sendEmail(email, subject, getString(R.string.commonutils_help_email_text))
 
+/** Sends an "about me" contact email with a pre-filled body. */
 fun Context.sendEmailAboutMe(
     email: String,
     subject: String,
 ) = sendEmail(email, subject, getString(R.string.commonutils_about_email_text))
 
+/** Sends a bug report email with a pre-filled body. */
 fun Fragment.sendEmailBugReport(
     email: String,
     subject: String,

--- a/lib/src/main/java/de/lemke/commonutils/ExportUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ExportUtils.kt
@@ -43,6 +43,7 @@ private const val MIME_TYPE_PNG = "image/png"
 private const val EXTENSION_PNG = ".png"
 private const val COMPRESS_QUALITY_MAX = 100
 
+/** Target directory for exported images. */
 enum class SaveLocation {
     CUSTOM,
     DOWNLOADS,
@@ -60,6 +61,7 @@ enum class SaveLocation {
         fun getLocalizedEntries(context: Context) = entries.map { it.toLocalizedString(context) }.toTypedArray()
     }
 
+    /** Returns a user-facing label for this save location. */
     fun toLocalizedString(context: Context): String =
         when (this) {
             CUSTOM -> context.getString(R.string.commonutils_custom)
@@ -69,6 +71,7 @@ enum class SaveLocation {
         }
 }
 
+/** Exports [bitmap] to the given [saveLocation]; launches the document picker if needed via [activityResultLauncher]. */
 fun Fragment.exportBitmap(
     saveLocation: SaveLocation,
     bitmap: Bitmap,
@@ -76,6 +79,7 @@ fun Fragment.exportBitmap(
     activityResultLauncher: ActivityResultLauncher<Intent>?,
 ): Boolean = requireContext().exportBitmap(saveLocation, bitmap, filename, activityResultLauncher)
 
+/** Exports [bitmap] to the given [saveLocation]; launches the document picker if needed via [activityResultLauncher]. */
 fun Context.exportBitmap(
     saveLocation: SaveLocation,
     bitmap: Bitmap,
@@ -125,6 +129,7 @@ fun Context.exportBitmap(
         }
     }
 
+/** Compresses [bitmap] as PNG and writes it to [uri], showing a toast on success or failure. */
 fun Context.saveBitmapToUri(
     uri: Uri?,
     bitmap: Bitmap?,
@@ -154,6 +159,7 @@ fun Context.saveBitmapToUri(
     }
 }
 
+/** Converts this string to a filesystem-safe filename, appending a timestamp and [extension]. */
 fun String.toSafeFileName(extension: String): String =
     "${this}_${SimpleDateFormat("yyyy_MM_dd_HH_mm_ss", Locale.getDefault()).format(Date())}"
         .replace("https://", "")

--- a/lib/src/main/java/de/lemke/commonutils/InAppReviewUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/InAppReviewUtils.kt
@@ -28,10 +28,13 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 private const val TAG = "InAppReviewUtils"
 private const val MIN_DAYS_BETWEEN_REVIEWS = 14L
 
+/** Returns the timestamp of the last in-app review request in milliseconds, defaulting to now if unset. */
 fun AppCompatActivity.getLastInAppReview() = getSharedPreferences(TAG, MODE_PRIVATE).getLong("lastInAppReview", currentTimeMillis())
 
+/** Persists the current time as the last in-app review timestamp. */
 fun AppCompatActivity.setInAppReview() = getSharedPreferences(TAG, MODE_PRIVATE).edit { putLong("lastInAppReview", currentTimeMillis()) }
 
+/** Returns `true` if at least 14 days have passed since the last in-app review was shown. */
 @Suppress("TooGenericExceptionCaught")
 fun AppCompatActivity.canShowInAppReview() =
     try {
@@ -43,12 +46,14 @@ fun AppCompatActivity.canShowInAppReview() =
         false
     }
 
+/** Attempts to show the in-app review flow; finishes the activity whether the review is shown or skipped. */
 fun AppCompatActivity.showInAppReviewOrFinish() =
     showInAppReview(
         onNotAllowed = { finishAfterTransition() },
         onCompleted = { finishAfterTransition() },
     )
 
+/** Requests the in-app review flow if the cooldown period has elapsed; silently skips otherwise. */
 fun AppCompatActivity.showInAppReviewIfPossible() = showInAppReview()
 
 @Suppress("TooGenericExceptionCaught")

--- a/lib/src/main/java/de/lemke/commonutils/LifecycleCollectors.kt
+++ b/lib/src/main/java/de/lemke/commonutils/LifecycleCollectors.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.Lifecycle.State.STARTED
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.StateFlow
 
+/** Collects [flow] emissions and delivers each value to [onEach] while the activity is at least [minActiveState]. */
 inline fun <T> AppCompatActivity.collectState(
     flow: StateFlow<T>,
     minActiveState: State = STARTED,
@@ -32,6 +33,7 @@ inline fun <T> AppCompatActivity.collectState(
     flow.collect { onEach(it) }
 }
 
+/** Collects [flow] emissions and delivers each value to [onEach] while the fragment view is at least [minActiveState]. */
 inline fun <T> Fragment.collectState(
     flow: StateFlow<T>,
     minActiveState: State = STARTED,
@@ -40,6 +42,7 @@ inline fun <T> Fragment.collectState(
     flow.collect { onEach(it) }
 }
 
+/** Consumes events from [channel] and delivers each to [onEach] while the activity is at least [minActiveState]. */
 inline fun <T> AppCompatActivity.collectEvents(
     channel: ReceiveChannel<T>,
     minActiveState: State = STARTED,
@@ -48,6 +51,7 @@ inline fun <T> AppCompatActivity.collectEvents(
     for (event in channel) onEach(event)
 }
 
+/** Consumes events from [channel] and delivers each to [onEach] while the fragment view is at least [minActiveState]. */
 inline fun <T> Fragment.collectEvents(
     channel: ReceiveChannel<T>,
     minActiveState: State = STARTED,

--- a/lib/src/main/java/de/lemke/commonutils/OpenUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/OpenUtils.kt
@@ -35,11 +35,13 @@ import androidx.fragment.app.Fragment
 
 private const val TAG = "OpenUtils"
 
+/** Opens the app with [packageName], trying the local install first if [tryLocalFirst] is `true`, otherwise opens the Play Store. */
 fun Fragment.openApp(
     packageName: String,
     tryLocalFirst: Boolean,
 ): Boolean = requireContext().openApp(packageName, tryLocalFirst)
 
+/** Opens the app with [packageName], trying the local install first if [tryLocalFirst] is `true`, otherwise opens the Play Store. */
 fun Context.openApp(
     packageName: String,
     tryLocalFirst: Boolean,
@@ -84,9 +86,11 @@ private fun Context.openAppWithPackageNameOnStore(packageName: String): Boolean 
     return false
 }
 
+/** Returns `true` if per-app language settings are supported (Android 13+). */
 @ChecksSdkIntAtLeast(api = TIRAMISU)
 fun areAppLocalSettingsSupported(): Boolean = SDK_INT >= TIRAMISU
 
+/** Opens the system per-app language settings screen for this app. */
 @RequiresApi(TIRAMISU)
 fun Fragment.openAppLocaleSettings(): Boolean {
     if (!areAppLocalSettingsSupported()) {
@@ -103,6 +107,7 @@ fun Fragment.openAppLocaleSettings(): Boolean {
     }
 }
 
+/** Opens the system application settings screen for this app. */
 fun Context.openApplicationSettings(): Boolean =
     try {
         startActivity(

--- a/lib/src/main/java/de/lemke/commonutils/PredictiveBackGestureUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/PredictiveBackGestureUtils.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.launch
 
 private const val TAG = "PredictiveBackGestureUtils"
 
+/** Registers [onBackPressedLogic] as the back handler, enabled whenever [backPressLogicEnabled] emits `true`. */
 inline fun Fragment.addOnBackLogic(
     backPressLogicEnabled: StateFlow<Boolean>,
     crossinline onBackPressedLogic: () -> Unit = {},
@@ -76,16 +77,22 @@ inline fun Fragment.addOnBackLogic(
     }
 }
 
+/** Path interpolator matching the predictive-back motion spec deceleration curve. */
 val GestureInterpolator = PathInterpolatorCompat.create(0f, 0f, 0f, 1f)
 
+/** [ViewOutlineProvider] that applies rounded corners scaled with back-gesture progress. */
 class BackAnimationOutlineProvider : ViewOutlineProvider() {
+    /** Current corner radius in pixels, driven by [progress]. */
     var radius = 0f
+
+    /** Gesture progress in [0, 1]; setting it updates [radius] proportionally. */
     var progress: Float = 0f
         set(value) {
             field = value
             radius = value * 100f
         }
 
+    /** Applies a rounded-rectangle outline scaled to the current [radius]. */
     override fun getOutline(
         view: View,
         outline: Outline,
@@ -94,6 +101,7 @@ class BackAnimationOutlineProvider : ViewOutlineProvider() {
     }
 }
 
+/** Adds a predictive-back animation to [animatedView] that scales and shifts it as the user swipes back. */
 fun AppCompatActivity.setCustomBackAnimation(
     animatedView: View,
     backEnabled: StateFlow<Boolean>? = null,
@@ -157,6 +165,7 @@ fun AppCompatActivity.setCustomBackAnimation(
     backEnabled?.apply { lifecycleScope.launch { flowWithLifecycle(lifecycle).collectLatest { enable -> callback.isEnabled = enable } } }
 }
 
+/** Makes the activity window transparent or restores its default background, required for the predictive-back animation. */
 fun AppCompatActivity.setWindowTransparent(transparent: Boolean) {
     window.apply {
         if (transparent) {
@@ -171,6 +180,7 @@ fun AppCompatActivity.setWindowTransparent(transparent: Boolean) {
     }
 }
 
+/** The theme-appropriate default window background color for this activity. */
 val AppCompatActivity.defaultWindowBackground: Int
     @SuppressLint("RestrictedApi", "PrivateResource")
     get() = if (isLightTheme(this)) sesl_round_and_bgcolor_light else sesl_round_and_bgcolor_dark

--- a/lib/src/main/java/de/lemke/commonutils/PredictiveBackGestureUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/PredictiveBackGestureUtils.kt
@@ -101,7 +101,7 @@ class BackAnimationOutlineProvider : ViewOutlineProvider() {
     }
 }
 
-/** Adds a predictive-back animation to [animatedView] that scales and shifts it as the user swipes back. */
+/** Adds a predictive-back animation to [animatedView] that scales and shifts it as the user swipes back, with optional in-app review. */
 fun AppCompatActivity.setCustomBackAnimation(
     animatedView: View,
     backEnabled: StateFlow<Boolean>? = null,

--- a/lib/src/main/java/de/lemke/commonutils/PreferenceUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/PreferenceUtils.kt
@@ -39,6 +39,7 @@ import dev.oneuiproject.oneui.widget.RelativeLink
 
 private const val TAG = "PreferenceUtils"
 
+/** Adds a relative-links card with "Share app" and "Rate app" actions to the preference screen. */
 fun PreferenceFragmentCompat.addShareAppAndRateRelativeLinksCard() {
     addRelativeLinksCard(
         RelativeLink(getString(R.string.commonutils_share_app)) { shareApp() },
@@ -46,6 +47,7 @@ fun PreferenceFragmentCompat.addShareAppAndRateRelativeLinksCard() {
     )
 }
 
+/** Initializes the standard common-utils preferences (dark mode, save location, language, dev options, more info). */
 fun PreferenceFragmentCompat.initCommonUtilsPreferences() {
     initDarkMode()
     initImageSaveLocation()

--- a/lib/src/main/java/de/lemke/commonutils/SearchUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/SearchUtils.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 private const val TAG = "SearchUtils"
 
+/** Returns a [ToolbarLayout.SearchModeListener] that updates [search] on query changes and persists the last query. */
 fun AppCompatActivity.getCommonUtilsSearchListener(
     search: MutableStateFlow<String?>,
     @StringRes queryHint: Int? = null,

--- a/lib/src/main/java/de/lemke/commonutils/SharingUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/SharingUtils.kt
@@ -44,8 +44,10 @@ private const val MIME_TYPE_PNG = "image/png"
 private const val TAG = "SharingUtils"
 private const val COMPRESS_QUALITY_MAX = 100
 
+/** Shares the app's Play Store link via the system share sheet. */
 fun Fragment.shareApp(): Boolean = requireContext().shareApp()
 
+/** Shares the app's Play Store link via the system share sheet. */
 fun Context.shareApp(): Boolean =
     safeStartActivity(
         Intent.createChooser(
@@ -58,11 +60,13 @@ fun Context.shareApp(): Boolean =
         ),
     )
 
+/** Shares [text] via the system share sheet with an optional chooser [title]. */
 fun Fragment.shareText(
     text: String,
     title: String? = null,
 ): Boolean = requireContext().shareText(text, title)
 
+/** Shares [text] via the system share sheet with an optional chooser [title]. */
 fun Context.shareText(
     text: String,
     title: String? = null,
@@ -76,11 +80,13 @@ fun Context.shareText(
     }
 }
 
+/** Copies [text] to the clipboard under [label] and shows a confirmation toast. */
 fun Fragment.copyToClipboard(
     text: String,
     label: String,
 ): Boolean = requireContext().copyToClipboard(text, label)
 
+/** Copies [text] to the clipboard under [label] and shows a confirmation toast. */
 fun Context.copyToClipboard(
     text: String,
     label: String,
@@ -90,6 +96,7 @@ fun Context.copyToClipboard(
     return true
 }
 
+/** Copies [bitmap] to the clipboard via a cached file URI under [label]. */
 fun Context.copyToClipboard(
     bitmap: Bitmap,
     label: String,
@@ -107,24 +114,28 @@ fun Context.copyToClipboard(
     return true
 }
 
+/** Copies this bitmap to the clipboard via a cached file URI under [label]. */
 fun Bitmap.copyToClipboard(
     context: Context,
     label: String,
     shareFileName: String,
 ): Boolean = context.copyToClipboard(this, label, shareFileName)
 
+/** Shares [bitmap] via the system share sheet, optionally including [shareText]. */
 fun Fragment.shareBitmap(
     bitmap: Bitmap,
     shareFileName: String,
     shareText: String? = null,
 ): Boolean = bitmap.share(requireContext(), shareFileName, shareText)
 
+/** Shares [bitmap] via the system share sheet, optionally including [shareText]. */
 fun Context.shareBitmap(
     bitmap: Bitmap,
     shareFileName: String,
     shareText: String? = null,
 ): Boolean = bitmap.share(this, shareFileName, shareText)
 
+/** Writes this bitmap to a cache file and shares it via the system share sheet, optionally including [shareText]. */
 fun Bitmap.share(
     context: Context,
     shareFileName: String,
@@ -153,16 +164,19 @@ fun Bitmap.share(
         false
     }
 
+/** Shares [bitmap] directly via Samsung Quick Share if available, falling back to the system share sheet. */
 fun Fragment.quickShareBitmap(
     bitmap: Bitmap,
     shareFileName: String,
 ): Boolean = bitmap.quickShare(requireContext(), shareFileName)
 
+/** Shares [bitmap] directly via Samsung Quick Share if available, falling back to the system share sheet. */
 fun Context.quickShareBitmap(
     bitmap: Bitmap,
     shareFileName: String,
 ): Boolean = bitmap.quickShare(this, shareFileName)
 
+/** Shares this bitmap directly via Samsung Quick Share if available, falling back to the system share sheet. */
 fun Bitmap.quickShare(
     context: Context,
     shareFileName: String,
@@ -180,8 +194,10 @@ fun Bitmap.quickShare(
     }
 }
 
+/** Shares this file via the system share sheet. */
 fun File.share(context: Context): Boolean = listOf(this).share(context)
 
+/** Shares all files in this list via the system share sheet (multi-file if more than one). */
 fun List<File>.share(context: Context): Boolean {
     val contentUris = map { f -> f.getFileUri(context) }
 
@@ -234,6 +250,7 @@ private fun Context.safeStartActivity(intent: Intent): Boolean {
     }
 }
 
+/** Returns `true` if the Samsung Quick Share app is installed on this device. */
 fun Context.isSamsungQuickShareAvailable(): Boolean =
     try {
         packageManager.getPackageInfo(SAMSUNG_QUICK_SHARE_PACKAGE, 0)
@@ -244,4 +261,5 @@ fun Context.isSamsungQuickShareAvailable(): Boolean =
         Log.i(TAG, "isSamsungQuickShareAvailable: $it")
     }
 
+/** Returns a content URI for this file via the app's FileProvider, usable in share intents. */
 fun File.getFileUri(context: Context): Uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", this)

--- a/lib/src/main/java/de/lemke/commonutils/SharingUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/SharingUtils.kt
@@ -194,10 +194,10 @@ fun Bitmap.quickShare(
     }
 }
 
-/** Shares this file via the system share sheet. */
+/** Shares this image file via the system share sheet. */
 fun File.share(context: Context): Boolean = listOf(this).share(context)
 
-/** Shares all files in this list via the system share sheet (multi-file if more than one). */
+/** Shares all image files in this list via the system share sheet (multi-file if more than one). */
 fun List<File>.share(context: Context): Boolean {
     val contentUris = map { f -> f.getFileUri(context) }
 

--- a/lib/src/main/java/de/lemke/commonutils/SnackBarUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/SnackBarUtils.kt
@@ -26,6 +26,7 @@ import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_SHORT
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.SESL_SNACKBAR_TYPE_SUGGESTION
 
+/** Shows a OneUI suggestive snackbar with [msg] string resource and an optional action. */
 inline fun Fragment.suggestiveSnackBar(
     @StringRes msg: Int,
     view: View? = null,
@@ -34,6 +35,7 @@ inline fun Fragment.suggestiveSnackBar(
     crossinline action: (Snackbar.() -> Unit) = { dismiss() },
 ) = requireActivity().suggestiveSnackBar(msg, view, duration, actionText, action)
 
+/** Shows a OneUI suggestive snackbar with [msg] and an optional action. */
 inline fun Fragment.suggestiveSnackBar(
     msg: String,
     view: View? = null,
@@ -42,6 +44,7 @@ inline fun Fragment.suggestiveSnackBar(
     crossinline action: (Snackbar.() -> Unit) = { dismiss() },
 ) = requireActivity().suggestiveSnackBar(msg, view, duration, actionText, action)
 
+/** Shows a OneUI suggestive snackbar with [msg] string resource and an optional action. */
 inline fun Activity.suggestiveSnackBar(
     @StringRes msg: Int,
     view: View? = null,
@@ -50,6 +53,7 @@ inline fun Activity.suggestiveSnackBar(
     crossinline action: (Snackbar.() -> Unit) = { dismiss() },
 ) = suggestiveSnackBar(getString(msg), view, duration, actionText, action)
 
+/** Shows a OneUI suggestive snackbar with [msg] and an optional action. */
 inline fun Activity.suggestiveSnackBar(
     msg: String,
     view: View? = null,

--- a/lib/src/main/java/de/lemke/commonutils/SplashUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/SplashUtils.kt
@@ -37,6 +37,7 @@ private const val TAG = "SplashUtils"
 private const val SPLASH_ANIMATION_DURATION_MS = 400L
 private const val SPLASH_SCALE_FACTOR = 1.2f
 
+/** Configures the splash screen to stay visible while [condition] holds, then animates it out while fading in [root]. */
 fun AppCompatActivity.configureCommonUtilsSplashScreen(
     splashScreen: SplashScreen,
     root: View,

--- a/lib/src/main/java/de/lemke/commonutils/TipPopupUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/TipPopupUtils.kt
@@ -28,12 +28,14 @@ import dev.oneuiproject.oneui.design.R as designR
 
 private const val TAG = "TipPopupUtils"
 
+/** Shows a tip popup anchored to this view with a full-screen touch-blocking overlay. */
 fun View.showTouchBlockingTipPopup(
     @StringRes messageResId: Int,
     @StringRes actionTextResId: Int? = null,
     action: () -> Unit = {},
 ) = showTouchBlockingTipPopup(context.getString(messageResId), actionTextResId?.let { context.getString(it) }, action)
 
+/** Shows a tip popup anchored to this view with a full-screen touch-blocking overlay. */
 fun View.showTouchBlockingTipPopup(
     message: String,
     actionText: String? = null,
@@ -42,12 +44,14 @@ fun View.showTouchBlockingTipPopup(
     showTipPopupWithOverlay(TouchBlockingView(context), message, actionText, action).setOutsideTouchEnabled(false)
 }
 
+/** Shows a tip popup anchored to this view with a semi-transparent dimming overlay. */
 fun View.showDimmingTipPopup(
     @StringRes messageResId: Int,
     @StringRes actionTextResId: Int? = null,
     action: () -> Unit = {},
 ) = showDimmingTipPopup(context.getString(messageResId), actionTextResId?.let { context.getString(it) }, action)
 
+/** Shows a tip popup anchored to this view with a semi-transparent dimming overlay. */
 fun View.showDimmingTipPopup(
     message: String,
     actionText: String? = null,

--- a/lib/src/main/java/de/lemke/commonutils/URLUtils.kt
+++ b/lib/src/main/java/de/lemke/commonutils/URLUtils.kt
@@ -28,16 +28,22 @@ import java.net.URLEncoder
 
 private const val TAG = "URLUtils"
 
+/** Returns this string with an `https://` prefix, unless it already starts with `http://` or `https://`. */
 fun String.withHttps() = if (this.startsWith("http://") || this.startsWith("https://")) this else "https://$this"
 
+/** Removes `https://`, `http://`, and a trailing `/` from this string. */
 fun String.withoutHttps() = this.removePrefix("https://").removePrefix("http://").removeSuffix("/")
 
+/** Replaces `&` with its percent-encoded form `%26` to prevent URL parameter splitting. */
 fun String.urlEncodeAmpersand() = this.replace("&", "%26")
 
+/** Percent-encodes this string using UTF-8. */
 fun String.urlEncode(): String = URLEncoder.encode(this, "UTF-8")
 
+/** Opens [url] in the default browser, showing a toast if no browser is available or the URL is blank. */
 fun Fragment.openURL(url: String?): Boolean = requireContext().openURL(url)
 
+/** Opens [url] in the default browser, showing a toast if no browser is available or the URL is blank. */
 @Suppress("TooGenericExceptionCaught")
 fun Context.openURL(url: String?): Boolean =
     try {

--- a/lib/src/main/java/de/lemke/commonutils/data/DelegatesAdvanced.kt
+++ b/lib/src/main/java/de/lemke/commonutils/data/DelegatesAdvanced.kt
@@ -31,40 +31,48 @@ import kotlin.reflect.KProperty
  */
 val SharedPreferences.delegates get() = SharedPreferenceDelegates(this)
 
+/** Factory for type-safe [ReadWriteProperty] delegates backed by [SharedPreferences]. */
 @SuppressLint("CommitPrefEdits")
 class SharedPreferenceDelegates(
     private val prefs: SharedPreferences,
 ) {
+    /** Delegate that reads/writes a [Boolean] preference. */
     fun boolean(
         default: Boolean = false,
         key: String? = null,
     ): ReadWriteProperty<Any, Boolean> = create(default, key, prefs::getBoolean, prefs.edit()::putBoolean)
 
+    /** Delegate that reads/writes an [Int] preference. */
     fun int(
         default: Int = 0,
         key: String? = null,
     ): ReadWriteProperty<Any, Int> = create(default, key, prefs::getInt, prefs.edit()::putInt)
 
+    /** Delegate that reads/writes a [Float] preference. */
     fun float(
         default: Float = 0f,
         key: String? = null,
     ): ReadWriteProperty<Any, Float> = create(default, key, prefs::getFloat, prefs.edit()::putFloat)
 
+    /** Delegate that reads/writes a [Long] preference. */
     fun long(
         default: Long = 0L,
         key: String? = null,
     ): ReadWriteProperty<Any, Long> = create(default, key, prefs::getLong, prefs.edit()::putLong)
 
+    /** Delegate that reads/writes a [String] preference. */
     fun string(
         default: String = "",
         key: String? = null,
     ): ReadWriteProperty<Any, String> = create(default, key, { k, d -> prefs.getString(k, d) ?: d }, prefs.edit()::putString)
 
+    /** Delegate that reads/writes a [Set]<[String]> preference. */
     fun stringSet(
         default: Set<String> = emptySet(),
         key: String? = null,
     ): ReadWriteProperty<Any, Set<String>> = create(default, key, { k, d -> prefs.getStringSet(k, d) ?: d }, prefs.edit()::putStringSet)
 
+    /** Delegate that reads/writes a dark mode flag stored as `"1"`/`"0"` for legacy HorizontalRadioPreference compatibility. */
     fun darkMode(
         default: Boolean = false,
         key: String? = null,
@@ -76,6 +84,7 @@ class SharedPreferenceDelegates(
             { k, v -> prefs.edit().putString(k, if (v) "1" else "0") },
         )
 
+    /** Delegate that reads/writes a [SaveLocation] preference, forcing [SaveLocation.CUSTOM] on API ≤29. */
     fun saveLocation(
         default: SaveLocation = SaveLocation.default,
         key: String? = null,

--- a/lib/src/main/java/de/lemke/commonutils/data/SettingsRepository.kt
+++ b/lib/src/main/java/de/lemke/commonutils/data/SettingsRepository.kt
@@ -26,8 +26,10 @@ import androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode
 import androidx.preference.PreferenceManager
 import de.lemke.commonutils.SaveLocation
 
+/** Global singleton for accessing common-utils app settings; must be initialized via [initCommonUtilsSettingsAndSetDarkMode]. */
 lateinit var commonUtilsSettings: SettingsRepository
 
+/** SharedPreferences-backed repository for common-utils app settings. */
 class SettingsRepository(
     preferences: SharedPreferences,
 ) {
@@ -41,6 +43,7 @@ class SettingsRepository(
     var imageSaveLocation: SaveLocation by preferences.delegates.saveLocation(SaveLocation.default)
 }
 
+/** Initializes [commonUtilsSettings] from the default shared preferences and applies the saved dark mode setting. */
 fun Context.initCommonUtilsSettingsAndSetDarkMode() {
     commonUtilsSettings = SettingsRepository(PreferenceManager.getDefaultSharedPreferences(this))
     when {

--- a/lib/src/main/java/de/lemke/commonutils/di/CoroutineDispatchers.kt
+++ b/lib/src/main/java/de/lemke/commonutils/di/CoroutineDispatchers.kt
@@ -23,29 +23,36 @@ import javax.inject.Qualifier
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
+/** Hilt qualifier for [kotlinx.coroutines.Dispatchers.IO]. */
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class IoDispatcher
 
+/** Hilt qualifier for [kotlinx.coroutines.Dispatchers.Default]. */
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class DefaultDispatcher
 
+/** Hilt qualifier for [kotlinx.coroutines.Dispatchers.Main]. */
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class MainDispatcher
 
+/** Hilt module that provides coroutine dispatcher bindings for [IoDispatcher], [DefaultDispatcher], and [MainDispatcher]. */
 @Module
 @InstallIn(SingletonComponent::class)
 object CoroutineDispatchersModule {
+    /** Provides [kotlinx.coroutines.Dispatchers.IO] for I/O-bound work. */
     @Provides
     @IoDispatcher
     fun provideIo(): CoroutineDispatcher = Dispatchers.IO
 
+    /** Provides [kotlinx.coroutines.Dispatchers.Default] for CPU-bound work. */
     @Provides
     @DefaultDispatcher
     fun provideDefault(): CoroutineDispatcher = Dispatchers.Default
 
+    /** Provides [kotlinx.coroutines.Dispatchers.Main] for UI-thread work. */
     @Provides
     @MainDispatcher
     fun provideMain(): CoroutineDispatcher = Dispatchers.Main

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutActivity.kt
@@ -173,6 +173,7 @@ class CommonUtilsAboutActivity : AppCompatActivity() {
 
     companion object {
         private const val TAG = "CommonUtilsAboutActivity"
+
         /** Static version string displayed in the about screen; takes precedence if non-empty. */
         var appVersion = ""
 

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutActivity.kt
@@ -90,7 +90,9 @@ class CommonUtilsAboutActivity : AppCompatActivity() {
                     // For immediate updates, you might not receive RESULT_OK because
                     // the update should already be finished by the time control is given back to your app.
                     RESULT_OK -> Log.d("InAppUpdate", "Update successful")
+
                     RESULT_CANCELED -> Log.w("InAppUpdate", "Update canceled")
+
                     RESULT_IN_APP_UPDATE_FAILED -> Log.e("InAppUpdate", "Update failed")
                 }
             }

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutActivity.kt
@@ -53,6 +53,7 @@ import dev.oneuiproject.oneui.layout.AppInfoLayout.Status.UpdateAvailable
 import kotlinx.coroutines.launch
 import dev.oneuiproject.oneui.design.R as designR
 
+/** Pre-built About screen that shows the app version, optional text, and an in-app update check. */
 class CommonUtilsAboutActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAboutBinding
     private lateinit var appUpdateManager: AppUpdateManager
@@ -172,8 +173,13 @@ class CommonUtilsAboutActivity : AppCompatActivity() {
 
     companion object {
         private const val TAG = "CommonUtilsAboutActivity"
+        /** Static version string displayed in the about screen; takes precedence if non-empty. */
         var appVersion = ""
+
+        /** Suspend function used to resolve the version string at display time; used when [appVersion] is empty. */
         var getAppVersion = suspend { "" }
+
+        /** Optional extra text shown below the version; rendered as a [SpannableString] for clickable spans. */
         var optionalText: SpannableString? = null
     }
 }

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutMeActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutMeActivity.kt
@@ -240,6 +240,7 @@ class CommonUtilsAboutMeActivity : AppCompatActivity() {
 
     companion object {
         private const val BACK_COLLAPSE_THRESHOLD = 0.3f
+
         /** Optional callback invoked when the user taps the share button; defaults to a no-op. */
         var onShareApp: (activity: Activity) -> Unit = {}
     }

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutMeActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsAboutMeActivity.kt
@@ -49,6 +49,7 @@ import kotlin.math.abs
 import kotlinx.coroutines.flow.MutableStateFlow
 import dev.oneuiproject.oneui.design.R as designR
 
+/** Pre-built About Me screen that presents developer info and an optional share-app action. */
 class CommonUtilsAboutMeActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAboutMeBinding
     private val appBarListener: AboutAppBarListener = AboutAppBarListener()
@@ -239,6 +240,7 @@ class CommonUtilsAboutMeActivity : AppCompatActivity() {
 
     companion object {
         private const val BACK_COLLAPSE_THRESHOLD = 0.3f
+        /** Optional callback invoked when the user taps the share button; defaults to a no-op. */
         var onShareApp: (activity: Activity) -> Unit = {}
     }
 }

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsLibsActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsLibsActivity.kt
@@ -50,6 +50,7 @@ import de.lemke.commonutils.setWindowTransparent
 import dev.oneuiproject.oneui.R as iconsR
 import dev.oneuiproject.oneui.design.R as designR
 
+/** Pre-built open-source licenses screen powered by AboutLibraries. */
 class CommonUtilsLibsActivity : AppCompatActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsOOBEActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsOOBEActivity.kt
@@ -123,6 +123,7 @@ class CommonUtilsOOBEActivity : AppCompatActivity() {
     companion object {
         private const val PROCEED_DELAY_MS = 500L
         private const val MIN_FULL_BUTTON_WIDTH_DP = 360
+
         /** Whether to persist TOS acceptance when the user proceeds; set via [setupCommonUtilsOOBEActivity]. */
         var setAcceptedTosVersion = true
 

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsOOBEActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsOOBEActivity.kt
@@ -41,6 +41,7 @@ import dev.oneuiproject.oneui.widget.OnboardingTipsItemView
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+/** Pre-built onboarding (OOBE) screen that presents feature tips and a TOS acceptance flow. */
 class CommonUtilsOOBEActivity : AppCompatActivity() {
     private lateinit var binding: ActivityOobeBinding
 
@@ -122,9 +123,16 @@ class CommonUtilsOOBEActivity : AppCompatActivity() {
     companion object {
         private const val PROCEED_DELAY_MS = 500L
         private const val MIN_FULL_BUTTON_WIDTH_DP = 360
+        /** Whether to persist TOS acceptance when the user proceeds; set via [setupCommonUtilsOOBEActivity]. */
         var setAcceptedTosVersion = true
+
+        /** Activity to launch after the user completes OOBE; mutually exclusive with [onContinue]. */
         var nextActivity: Class<*>? = null
+
+        /** Callback invoked when the user completes OOBE; mutually exclusive with [nextActivity]. */
         var onContinue: (() -> Unit)? = null
+
+        /** `true` if TOS content changed since the user last accepted; shown as a "new TOS" notice. */
         var tosChanged = false
     }
 }

--- a/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsSettingsActivity.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/activity/CommonUtilsSettingsActivity.kt
@@ -28,6 +28,7 @@ import de.lemke.commonutils.prepareActivityTransformationTo
 import de.lemke.commonutils.setCustomBackAnimation
 import kotlinx.coroutines.launch
 
+/** Pre-built settings screen backed by a [PreferenceFragmentCompat] with common-utils defaults. */
 class CommonUtilsSettingsActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingsCommonUtilsBinding
 
@@ -40,6 +41,7 @@ class CommonUtilsSettingsActivity : AppCompatActivity() {
         if (savedInstanceState == null) supportFragmentManager.beginTransaction().replace(R.id.settingsLayout, SettingsFragment()).commit()
     }
 
+    /** [PreferenceFragmentCompat] that inflates the configured preference XML resources. */
     class SettingsFragment : PreferenceFragmentCompat() {
         override fun onCreatePreferences(
             bundle: Bundle?,
@@ -64,6 +66,7 @@ class CommonUtilsSettingsActivity : AppCompatActivity() {
     }
 
     companion object {
+        /** Preference XML resource IDs inflated in order; configure via [setupCommonUtilsSettingsActivity]. */
         var preferences =
             listOf(
                 R.xml.preferences_design,
@@ -71,6 +74,8 @@ class CommonUtilsSettingsActivity : AppCompatActivity() {
                 R.xml.preferences_dev_options_delete_app_data,
                 R.xml.preferences_more_info,
             )
+
+        /** Optional suspend block run after preference inflation for app-specific init. */
         var initPreferences: suspend PreferenceFragmentCompat.() -> Unit = {}
     }
 }

--- a/lib/src/main/java/de/lemke/commonutils/ui/fragment/TransitionFragment.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/fragment/TransitionFragment.kt
@@ -23,6 +23,7 @@ import com.google.android.material.transition.MaterialElevationScale
 import com.google.android.material.transition.MaterialSharedAxis
 import com.google.android.material.transition.MaterialSharedAxis.Axis
 
+/** Base [Fragment] that wires up shared-element transitions on `onCreate`. */
 abstract class TransitionFragment(
     @LayoutRes layoutResId: Int,
     private val customEnterTransition: Transition = MaterialElevationScale(true),
@@ -43,6 +44,7 @@ abstract class TransitionFragment(
     }
 }
 
+/** [TransitionFragment] variant that uses [MaterialSharedAxis] transitions along the given [axis]. */
 abstract class TransitionFragmentSharedAxis(
     @LayoutRes layoutResId: Int,
     @Axis axis: Int,

--- a/lib/src/main/java/de/lemke/commonutils/ui/widget/DimmingView.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/widget/DimmingView.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.core.content.withStyledAttributes
 import de.lemke.commonutils.R
 
+/** Full-screen semi-transparent overlay used as a background for tip popups. */
 open class DimmingView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/lib/src/main/java/de/lemke/commonutils/ui/widget/InfoBottomSheet.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/widget/InfoBottomSheet.kt
@@ -108,7 +108,7 @@ class InfoBottomSheet : SemBottomSheetDialogFragment() {
             textGravity: Int? = null,
         ) = showInfoBottomSheet(childFragmentManager, title, message, textGravity)
 
-        /** Shows an [InfoBottomSheet] using the given [fragmentManager], [title], and [message]. */
+        /** Shows an [InfoBottomSheet] using the given [fragmentManager], [title], [message], and optional [textGravity]. */
         fun showInfoBottomSheet(
             fragmentManager: FragmentManager,
             title: String,

--- a/lib/src/main/java/de/lemke/commonutils/ui/widget/InfoBottomSheet.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/widget/InfoBottomSheet.kt
@@ -33,6 +33,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import de.lemke.commonutils.databinding.WidgetInfoBottomsheetBinding
 import dev.oneuiproject.oneui.app.SemBottomSheetDialogFragment
 
+/** Bottom sheet dialog that displays a title and a message, used for informational overlays. */
 class InfoBottomSheet : SemBottomSheetDialogFragment() {
     private lateinit var binding: WidgetInfoBottomsheetBinding
 
@@ -79,30 +80,35 @@ class InfoBottomSheet : SemBottomSheetDialogFragment() {
     }
 
     companion object {
+        /** Shows an [InfoBottomSheet] with string-resource [titleResId] and [messageResId]. */
         fun FragmentActivity.showInfoBottomSheet(
             @StringRes titleResId: Int,
             @StringRes messageResId: Int,
             textGravity: Int? = null,
         ) = showInfoBottomSheet(getString(titleResId), getString(messageResId), textGravity)
 
+        /** Shows an [InfoBottomSheet] with the given [title] and [message]. */
         fun FragmentActivity.showInfoBottomSheet(
             title: String,
             message: String,
             textGravity: Int? = null,
         ) = showInfoBottomSheet(supportFragmentManager, title, message, textGravity)
 
+        /** Shows an [InfoBottomSheet] with string-resource [titleResId] and [messageResId]. */
         fun Fragment.showInfoBottomSheet(
             @StringRes titleResId: Int,
             @StringRes messageResId: Int,
             textGravity: Int? = null,
         ) = showInfoBottomSheet(getString(titleResId), getString(messageResId), textGravity)
 
+        /** Shows an [InfoBottomSheet] with the given [title] and [message]. */
         fun Fragment.showInfoBottomSheet(
             title: String,
             message: String,
             textGravity: Int? = null,
         ) = showInfoBottomSheet(childFragmentManager, title, message, textGravity)
 
+        /** Shows an [InfoBottomSheet] using the given [fragmentManager], [title], and [message]. */
         fun showInfoBottomSheet(
             fragmentManager: FragmentManager,
             title: String,
@@ -123,8 +129,13 @@ class InfoBottomSheet : SemBottomSheetDialogFragment() {
                 }
         }
 
+        /** Bundle argument key for the sheet title. */
         const val KEY_TITLE = "key_title"
+
+        /** Bundle argument key for the sheet message. */
         const val KEY_MESSAGE = "key_message"
+
+        /** Bundle argument key for the text gravity applied to title and message. */
         const val KEY_TEXT_GRAVITY = "key_text_gravity"
     }
 }

--- a/lib/src/main/java/de/lemke/commonutils/ui/widget/NoEntryView.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/widget/NoEntryView.kt
@@ -34,13 +34,17 @@ import dev.oneuiproject.oneui.widget.RoundedLinearLayout
 
 private const val ANIMATION_START_DELAY_MS = 400L
 
+/** Empty-state view that shows a Lottie animation and a label when a list has no entries. */
 class NoEntryView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
     defStyleRes: Int = 0,
 ) : RoundedLinearLayout(context, attrs, defStyleAttr, defStyleRes) {
+    /** The Lottie animation view displayed in the center of this widget. */
     val lottieAnimationView: LottieAnimationView by lazy { findViewById(R.id.noEntryLottie) }
+
+    /** The label displayed below the animation. */
     val textView: TextView by lazy { findViewById(R.id.noEntryText) }
 
     init {
@@ -53,19 +57,23 @@ class NoEntryView @JvmOverloads constructor(
         hide()
     }
 
+    /** The label text shown below the animation. */
     var text: String
         get() = textView.text.toString()
         set(value) {
             textView.text = value
         }
 
+    /** Toggles visibility; if shown, hides [otherView], and vice versa. */
     fun toggle(otherView: View? = null) = updateVisibility(!isVisible, otherView)
 
+    /** Shows this view when [list] is empty, hides it (and shows [otherView]) otherwise. */
     fun updateVisibilityWith(
         list: List<*>,
         otherView: View? = null,
     ) = updateVisibility(list.isEmpty(), otherView)
 
+    /** Sets this view visible or hidden; when shown hides [otherView], when hidden shows [otherView]. */
     fun updateVisibility(
         visible: Boolean,
         otherView: View? = null,
@@ -77,6 +85,7 @@ class NoEntryView @JvmOverloads constructor(
         otherView?.isVisible = true
     }
 
+    /** Makes this view visible and starts the Lottie animation after a short delay. */
     fun show() {
         lottieAnimationView.cancelAnimation()
         lottieAnimationView.progress = 0f
@@ -86,6 +95,7 @@ class NoEntryView @JvmOverloads constructor(
         lottieAnimationView.postDelayed({ lottieAnimationView.playAnimation() }, ANIMATION_START_DELAY_MS)
     }
 
+    /** Hides this view. */
     fun hide() {
         isVisible = false
     }

--- a/lib/src/main/java/de/lemke/commonutils/ui/widget/TouchBlockingView.kt
+++ b/lib/src/main/java/de/lemke/commonutils/ui/widget/TouchBlockingView.kt
@@ -18,6 +18,7 @@ package de.lemke.commonutils.ui.widget
 import android.content.Context
 import android.util.AttributeSet
 
+/** Full-screen overlay that intercepts all touch events, preventing interaction with content behind it. */
 open class TouchBlockingView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,


### PR DESCRIPTION
## Summary

- Adds one-line KDoc to every public function, class, property, and constant across all 31 source files
- Covers root utilities, `data/`, `di/`, `ui/activity/`, `ui/fragment/`, `ui/widget/`
- No logic changes — pure documentation

## Test plan

- [x] `./gradlew assembleRelease` passes (verified locally)
- [ ] CI static-analysis + unit-test jobs green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive KDoc documentation across utility classes for improved developer reference.

* **API Updates**
  * Enhanced OOBE activity setup with optional `onContinue` callback for post-completion actions.
  * Updated About activity to resolve app version dynamically at display time instead of static configuration.
  * Expanded Settings activity configuration to accept preference lists for flexible layout management.
  * Added public `text` property to NoEntryView widget for dynamic label updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lemkinator/common-utils/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->