### PR TITLE
test: add targeted coverage tests and 12% Kover floor (Step 13)

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -125,5 +125,6 @@ kover {
                 )
             }
         }
+        verify { rule { minBound(12) } }
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/CheckAppStartTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/CheckAppStartTest.kt
@@ -21,13 +21,18 @@ import org.junit.jupiter.api.Test
 
 class CheckAppStartTest {
     private fun appStart(
-        result: AppStartResult = AppStartResult.NORMAL,
         versionCode: Int = 10,
         versionName: String = "1.0",
         lastVersionCode: Int = 9,
         lastVersionName: String = "0.9",
         tosVersion: Int = 1,
         acceptedTosVersion: Int = 1,
+        result: AppStartResult =
+            when {
+                lastVersionCode == -1 -> AppStartResult.FIRST_TIME
+                lastVersionCode < versionCode -> AppStartResult.FIRST_TIME_VERSION
+                else -> AppStartResult.NORMAL
+            },
     ) = AppStart(result, versionCode, versionName, lastVersionCode, lastVersionName, tosVersion, acceptedTosVersion)
 
     // region isFirstTime

--- a/lib/src/test/java/de/lemke/commonutils/CheckAppStartTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/CheckAppStartTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CheckAppStartTest {
+    private fun appStart(
+        result: AppStartResult = AppStartResult.NORMAL,
+        versionCode: Int = 10,
+        versionName: String = "1.0",
+        lastVersionCode: Int = 9,
+        lastVersionName: String = "0.9",
+        tosVersion: Int = 1,
+        acceptedTosVersion: Int = 1,
+    ) = AppStart(result, versionCode, versionName, lastVersionCode, lastVersionName, tosVersion, acceptedTosVersion)
+
+    // region isFirstTime
+
+    @Test
+    fun `isFirstTime is true when lastVersionCode is -1`() {
+        assertTrue(appStart(lastVersionCode = -1).isFirstTime)
+    }
+
+    @Test
+    fun `isFirstTime is false when lastVersionCode is not -1`() {
+        assertFalse(appStart(lastVersionCode = 5).isFirstTime)
+    }
+
+    // endregion
+
+    // region isFirstTimeVersion
+
+    @Test
+    fun `isFirstTimeVersion is true when lastVersionCode less than versionCode`() {
+        assertTrue(appStart(versionCode = 10, lastVersionCode = 9).isFirstTimeVersion)
+    }
+
+    @Test
+    fun `isFirstTimeVersion is false when codes are equal`() {
+        assertFalse(appStart(versionCode = 10, lastVersionCode = 10).isFirstTimeVersion)
+    }
+
+    @Test
+    fun `isFirstTimeVersion is false when lastVersionCode greater`() {
+        assertFalse(appStart(versionCode = 9, lastVersionCode = 10).isFirstTimeVersion)
+    }
+
+    // endregion
+
+    // region tosAccepted
+
+    @Test
+    fun `tosAccepted is true when acceptedTosVersion equals tosVersion`() {
+        assertTrue(appStart(tosVersion = 2, acceptedTosVersion = 2).tosAccepted)
+    }
+
+    @Test
+    fun `tosAccepted is true when acceptedTosVersion exceeds tosVersion`() {
+        assertTrue(appStart(tosVersion = 1, acceptedTosVersion = 3).tosAccepted)
+    }
+
+    @Test
+    fun `tosAccepted is false when acceptedTosVersion below tosVersion`() {
+        assertFalse(appStart(tosVersion = 2, acceptedTosVersion = 1).tosAccepted)
+    }
+
+    // endregion
+
+    // region shouldShowOOBE
+
+    @Test
+    fun `shouldShowOOBE is true on first install`() {
+        assertTrue(appStart(lastVersionCode = -1, tosVersion = 1, acceptedTosVersion = 1).shouldShowOOBE)
+    }
+
+    @Test
+    fun `shouldShowOOBE is true when TOS not accepted`() {
+        assertTrue(appStart(lastVersionCode = 5, tosVersion = 2, acceptedTosVersion = 1).shouldShowOOBE)
+    }
+
+    @Test
+    fun `shouldShowOOBE is false when returning user with accepted TOS`() {
+        assertFalse(appStart(lastVersionCode = 5, tosVersion = 1, acceptedTosVersion = 1).shouldShowOOBE)
+    }
+
+    // endregion
+
+    // region versionThresholdPassed
+
+    @Test
+    fun `versionThresholdPassed is true when threshold within upgrade range`() {
+        // lastVersionCode=5, versionCode=10 → range 5..<10
+        assertTrue(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(7))
+    }
+
+    @Test
+    fun `versionThresholdPassed is false when threshold below range`() {
+        assertFalse(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(4))
+    }
+
+    @Test
+    fun `versionThresholdPassed is true when threshold equals lastVersionCode (inclusive start)`() {
+        assertTrue(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(5))
+    }
+
+    @Test
+    fun `versionThresholdPassed is false when threshold equals versionCode (exclusive end)`() {
+        assertFalse(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(10))
+    }
+
+    @Test
+    fun `versionThresholdPassed is false when threshold above range`() {
+        assertFalse(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(11))
+    }
+
+    // endregion
+
+    // region toString
+
+    @Test
+    fun `toString includes versionCode`() {
+        val s = appStart(versionCode = 42).toString()
+        assertTrue(s.contains("42"))
+    }
+
+    @Test
+    fun `toString includes versionName`() {
+        val s = appStart(versionName = "2.3.4").toString()
+        assertTrue(s.contains("2.3.4"))
+    }
+
+    // endregion
+}

--- a/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ExportUtilsTest {
+    @Test
+    fun `toSafeFileName ends with given extension`() {
+        val result = "my photo".toSafeFileName(".png")
+        assertTrue(result.endsWith(".png"))
+    }
+
+    @Test
+    fun `toSafeFileName contains only alphanumeric and underscores before extension`() {
+        val result = "my photo".toSafeFileName(".png")
+        val base = result.removeSuffix(".png")
+        assertTrue(base.matches("[a-zA-Z0-9_]+".toRegex())) {
+            "Base '$base' contains disallowed characters"
+        }
+    }
+
+    @Test
+    fun `toSafeFileName removes https scheme`() {
+        val result = "https://example.com".toSafeFileName(".png")
+        assertFalse(result.contains("https"))
+    }
+
+    @Test
+    fun `toSafeFileName has no leading underscores before extension`() {
+        val result = "my photo".toSafeFileName(".png")
+        assertFalse(result.startsWith("_"))
+    }
+
+    @Test
+    fun `toSafeFileName has no consecutive underscores`() {
+        val result = "hello   world".toSafeFileName(".png")
+        assertFalse(result.contains("__"))
+    }
+
+    @Test
+    fun `toSafeFileName replaces special characters with underscores`() {
+        val result = "file@name!test".toSafeFileName(".png")
+        val base = result.removeSuffix(".png")
+        assertTrue(base.matches("[a-zA-Z0-9_]+".toRegex()))
+    }
+
+    @Test
+    fun `toSafeFileName appended extension is preserved literally`() {
+        val result = "test".toSafeFileName(".jpg")
+        assertTrue(result.endsWith(".jpg"))
+    }
+}

--- a/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
@@ -42,8 +42,18 @@ class ExportUtilsTest {
     }
 
     @Test
+    fun `toSafeFileName does not remove http scheme (only https is stripped)`() {
+        // Implementation only strips "https://" — "http://" becomes "http___"
+        val result = "http://example.com".toSafeFileName(".png")
+        assertFalse(result.startsWith("http___"), "http:// should produce safe chars, not 'http___'")
+        // Base must still be alphanumeric+undersscores only
+        val base = result.removeSuffix(".png")
+        assertTrue(base.matches("[a-zA-Z0-9_]+".toRegex()))
+    }
+
+    @Test
     fun `toSafeFileName has no leading underscores before extension`() {
-        val result = "my photo".toSafeFileName(".png")
+        val result = "  leading spaces".toSafeFileName(".png")
         assertFalse(result.startsWith("_"))
     }
 

--- a/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class SaveLocationRobolectricTest {
     private val ctx: Context get() = ApplicationProvider.getApplicationContext()
 

--- a/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SaveLocationRobolectricTest {
+    private val ctx: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `toLocalizedString returns non-blank for CUSTOM`() {
+        assertThat(SaveLocation.CUSTOM.toLocalizedString(ctx)).isNotEmpty()
+    }
+
+    @Test
+    fun `toLocalizedString returns non-blank for DOWNLOADS`() {
+        assertThat(SaveLocation.DOWNLOADS.toLocalizedString(ctx)).isNotEmpty()
+    }
+
+    @Test
+    fun `toLocalizedString returns non-blank for PICTURES`() {
+        assertThat(SaveLocation.PICTURES.toLocalizedString(ctx)).isNotEmpty()
+    }
+
+    @Test
+    fun `toLocalizedString returns non-blank for DCIM`() {
+        assertThat(SaveLocation.DCIM.toLocalizedString(ctx)).isNotEmpty()
+    }
+
+    @Test
+    fun `getLocalizedEntries returns 4 entries`() {
+        assertThat(SaveLocation.getLocalizedEntries(ctx)).hasLength(4)
+    }
+}

--- a/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
@@ -30,22 +30,22 @@ class SaveLocationRobolectricTest {
 
     @Test
     fun `toLocalizedString returns non-blank for CUSTOM`() {
-        assertThat(SaveLocation.CUSTOM.toLocalizedString(ctx)).isNotEmpty()
+        assertThat(SaveLocation.CUSTOM.toLocalizedString(ctx).isNotBlank()).isTrue()
     }
 
     @Test
     fun `toLocalizedString returns non-blank for DOWNLOADS`() {
-        assertThat(SaveLocation.DOWNLOADS.toLocalizedString(ctx)).isNotEmpty()
+        assertThat(SaveLocation.DOWNLOADS.toLocalizedString(ctx).isNotBlank()).isTrue()
     }
 
     @Test
     fun `toLocalizedString returns non-blank for PICTURES`() {
-        assertThat(SaveLocation.PICTURES.toLocalizedString(ctx)).isNotEmpty()
+        assertThat(SaveLocation.PICTURES.toLocalizedString(ctx).isNotBlank()).isTrue()
     }
 
     @Test
     fun `toLocalizedString returns non-blank for DCIM`() {
-        assertThat(SaveLocation.DCIM.toLocalizedString(ctx)).isNotEmpty()
+        assertThat(SaveLocation.DCIM.toLocalizedString(ctx).isNotBlank()).isTrue()
     }
 
     @Test

--- a/lib/src/test/java/de/lemke/commonutils/SaveLocationTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/SaveLocationTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SaveLocationTest {
+    // region fromStringOrDefault
+
+    @Test
+    fun `fromStringOrDefault returns CUSTOM for CUSTOM string`() {
+        assertEquals(SaveLocation.CUSTOM, SaveLocation.fromStringOrDefault("CUSTOM"))
+    }
+
+    @Test
+    fun `fromStringOrDefault returns DOWNLOADS for DOWNLOADS string`() {
+        assertEquals(SaveLocation.DOWNLOADS, SaveLocation.fromStringOrDefault("DOWNLOADS"))
+    }
+
+    @Test
+    fun `fromStringOrDefault returns PICTURES for PICTURES string`() {
+        assertEquals(SaveLocation.PICTURES, SaveLocation.fromStringOrDefault("PICTURES"))
+    }
+
+    @Test
+    fun `fromStringOrDefault returns DCIM for DCIM string`() {
+        assertEquals(SaveLocation.DCIM, SaveLocation.fromStringOrDefault("DCIM"))
+    }
+
+    @Test
+    fun `fromStringOrDefault returns default for null`() {
+        assertEquals(SaveLocation.default, SaveLocation.fromStringOrDefault(null))
+    }
+
+    @Test
+    fun `fromStringOrDefault returns default for unknown string`() {
+        assertEquals(SaveLocation.default, SaveLocation.fromStringOrDefault("UNKNOWN"))
+    }
+
+    @Test
+    fun `fromStringOrDefault is case-sensitive`() {
+        assertEquals(SaveLocation.default, SaveLocation.fromStringOrDefault("custom"))
+    }
+
+    // endregion
+
+    // region entryValues
+
+    @Test
+    fun `entryValues contains all enum names`() {
+        assertArrayEquals(arrayOf("CUSTOM", "DOWNLOADS", "PICTURES", "DCIM"), SaveLocation.entryValues)
+    }
+
+    // endregion
+
+    // region default
+
+    @Test
+    fun `default is CUSTOM`() {
+        assertEquals(SaveLocation.CUSTOM, SaveLocation.default)
+    }
+
+    // endregion
+}

--- a/lib/src/test/java/de/lemke/commonutils/URLUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/URLUtilsTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class URLUtilsTest {
+    // region withHttps
+
+    @Test
+    fun `withHttps prepends https to bare domain`() {
+        assertEquals("https://example.com", "example.com".withHttps())
+    }
+
+    @Test
+    fun `withHttps leaves https URL unchanged`() {
+        assertEquals("https://example.com", "https://example.com".withHttps())
+    }
+
+    @Test
+    fun `withHttps leaves http URL unchanged`() {
+        assertEquals("http://example.com", "http://example.com".withHttps())
+    }
+
+    @Test
+    fun `withHttps prepends https to path without scheme`() {
+        assertEquals("https://example.com/path", "example.com/path".withHttps())
+    }
+
+    // endregion
+
+    // region withoutHttps
+
+    @Test
+    fun `withoutHttps removes https scheme`() {
+        assertEquals("example.com", "https://example.com".withoutHttps())
+    }
+
+    @Test
+    fun `withoutHttps removes http scheme`() {
+        assertEquals("example.com", "http://example.com".withoutHttps())
+    }
+
+    @Test
+    fun `withoutHttps removes trailing slash`() {
+        assertEquals("example.com", "https://example.com/".withoutHttps())
+    }
+
+    @Test
+    fun `withoutHttps leaves plain domain unchanged`() {
+        assertEquals("example.com", "example.com".withoutHttps())
+    }
+
+    @Test
+    fun `withoutHttps removes only one prefix`() {
+        // https:// is removed, leaving http://example.com (http prefix also removed)
+        assertEquals("example.com", "https://http://example.com".withoutHttps())
+    }
+
+    // endregion
+
+    // region urlEncodeAmpersand
+
+    @Test
+    fun `urlEncodeAmpersand replaces single ampersand`() {
+        assertEquals("a%26b", "a&b".urlEncodeAmpersand())
+    }
+
+    @Test
+    fun `urlEncodeAmpersand replaces multiple ampersands`() {
+        assertEquals("a%26b%26c", "a&b&c".urlEncodeAmpersand())
+    }
+
+    @Test
+    fun `urlEncodeAmpersand leaves string without ampersand unchanged`() {
+        assertEquals("hello", "hello".urlEncodeAmpersand())
+    }
+
+    // endregion
+
+    // region urlEncode
+
+    @Test
+    fun `urlEncode encodes space as plus`() {
+        assertEquals("hello+world", "hello world".urlEncode())
+    }
+
+    @Test
+    fun `urlEncode encodes special characters`() {
+        assertEquals("a%26b", "a&b".urlEncode())
+    }
+
+    @Test
+    fun `urlEncode leaves alphanumeric unchanged`() {
+        assertEquals("abc123", "abc123".urlEncode())
+    }
+
+    // endregion
+}

--- a/lib/src/test/java/de/lemke/commonutils/URLUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/URLUtilsTest.kt
@@ -66,8 +66,8 @@ class URLUtilsTest {
     }
 
     @Test
-    fun `withoutHttps removes only one prefix`() {
-        // https:// is removed, leaving http://example.com (http prefix also removed)
+    fun `withoutHttps strips https then http from doubly-prefixed input`() {
+        // removePrefix("https://") → "http://example.com", then removePrefix("http://") → "example.com"
         assertEquals("example.com", "https://http://example.com".withoutHttps())
     }
 

--- a/lib/src/test/java/de/lemke/commonutils/data/DelegatesAdvancedTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/DelegatesAdvancedTest.kt
@@ -26,7 +26,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class DelegatesAdvancedTest {
     private lateinit var prefs: android.content.SharedPreferences
 

--- a/lib/src/test/java/de/lemke/commonutils/data/DelegatesAdvancedTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/DelegatesAdvancedTest.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import de.lemke.commonutils.SaveLocation
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class DelegatesAdvancedTest {
+    private lateinit var prefs: android.content.SharedPreferences
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        prefs = ctx.getSharedPreferences("test_prefs", Context.MODE_PRIVATE)
+        prefs.edit().clear().apply()
+    }
+
+    // region boolean
+
+    @Test
+    fun `boolean returns default when key absent`() {
+        class Holder {
+            var flag: Boolean by prefs.delegates.boolean(default = true)
+        }
+        assertThat(Holder().flag).isTrue()
+    }
+
+    @Test
+    fun `boolean round-trips written value`() {
+        class Holder {
+            var flag: Boolean by prefs.delegates.boolean(default = false)
+        }
+        val h = Holder()
+        h.flag = true
+        assertThat(Holder().flag).isTrue()
+    }
+
+    // endregion
+
+    // region int
+
+    @Test
+    fun `int returns default when key absent`() {
+        class Holder {
+            var n: Int by prefs.delegates.int(default = 42)
+        }
+        assertThat(Holder().n).isEqualTo(42)
+    }
+
+    @Test
+    fun `int round-trips written value`() {
+        class Holder {
+            var n: Int by prefs.delegates.int(default = 0)
+        }
+        val h = Holder()
+        h.n = 99
+        assertThat(Holder().n).isEqualTo(99)
+    }
+
+    // endregion
+
+    // region float
+
+    @Test
+    fun `float returns default when key absent`() {
+        class Holder {
+            var f: Float by prefs.delegates.float(default = 3.14f)
+        }
+        assertThat(Holder().f).isEqualTo(3.14f)
+    }
+
+    @Test
+    fun `float round-trips written value`() {
+        class Holder {
+            var f: Float by prefs.delegates.float(default = 0f)
+        }
+        val h = Holder()
+        h.f = 2.71f
+        assertThat(Holder().f).isEqualTo(2.71f)
+    }
+
+    // endregion
+
+    // region long
+
+    @Test
+    fun `long returns default when key absent`() {
+        class Holder {
+            var l: Long by prefs.delegates.long(default = 100L)
+        }
+        assertThat(Holder().l).isEqualTo(100L)
+    }
+
+    @Test
+    fun `long round-trips written value`() {
+        class Holder {
+            var l: Long by prefs.delegates.long(default = 0L)
+        }
+        val h = Holder()
+        h.l = Long.MAX_VALUE
+        assertThat(Holder().l).isEqualTo(Long.MAX_VALUE)
+    }
+
+    // endregion
+
+    // region string
+
+    @Test
+    fun `string returns default when key absent`() {
+        class Holder {
+            var s: String by prefs.delegates.string(default = "hello")
+        }
+        assertThat(Holder().s).isEqualTo("hello")
+    }
+
+    @Test
+    fun `string round-trips written value`() {
+        class Holder {
+            var s: String by prefs.delegates.string(default = "")
+        }
+        val h = Holder()
+        h.s = "world"
+        assertThat(Holder().s).isEqualTo("world")
+    }
+
+    // endregion
+
+    // region stringSet
+
+    @Test
+    fun `stringSet returns default when key absent`() {
+        class Holder {
+            var ss: Set<String> by prefs.delegates.stringSet(default = setOf("a", "b"))
+        }
+        assertThat(Holder().ss).containsExactly("a", "b")
+    }
+
+    @Test
+    fun `stringSet round-trips written value`() {
+        class Holder {
+            var ss: Set<String> by prefs.delegates.stringSet(default = emptySet())
+        }
+        val h = Holder()
+        h.ss = setOf("x", "y", "z")
+        assertThat(Holder().ss).containsExactly("x", "y", "z")
+    }
+
+    // endregion
+
+    // region darkMode
+
+    @Test
+    fun `darkMode returns default false when key absent`() {
+        class Holder {
+            var dm: Boolean by prefs.delegates.darkMode(default = false)
+        }
+        assertThat(Holder().dm).isFalse()
+    }
+
+    @Test
+    fun `darkMode round-trips true as string 1`() {
+        class Holder {
+            var dm: Boolean by prefs.delegates.darkMode(default = false)
+        }
+        val h = Holder()
+        h.dm = true
+        assertThat(Holder().dm).isTrue()
+        // Verify stored as "1"
+        assertThat(prefs.getString("dm", null)).isEqualTo("1")
+    }
+
+    @Test
+    fun `darkMode round-trips false as string 0`() {
+        class Holder {
+            var dm: Boolean by prefs.delegates.darkMode(default = true)
+        }
+        val h = Holder()
+        h.dm = false
+        assertThat(Holder().dm).isFalse()
+        assertThat(prefs.getString("dm", null)).isEqualTo("0")
+    }
+
+    // endregion
+
+    // region saveLocation
+
+    @Test
+    fun `saveLocation returns default when key absent`() {
+        class Holder {
+            var loc: SaveLocation by prefs.delegates.saveLocation(default = SaveLocation.PICTURES)
+        }
+        assertThat(Holder().loc).isEqualTo(SaveLocation.PICTURES)
+    }
+
+    @Test
+    fun `saveLocation round-trips DOWNLOADS`() {
+        class Holder {
+            var loc: SaveLocation by prefs.delegates.saveLocation()
+        }
+        val h = Holder()
+        h.loc = SaveLocation.DOWNLOADS
+        assertThat(Holder().loc).isEqualTo(SaveLocation.DOWNLOADS)
+    }
+
+    @Test
+    fun `saveLocation stores enum name in prefs`() {
+        class Holder {
+            var loc: SaveLocation by prefs.delegates.saveLocation()
+        }
+        val h = Holder()
+        h.loc = SaveLocation.DCIM
+        assertThat(prefs.getString("loc", null)).isEqualTo("DCIM")
+    }
+
+    // endregion
+
+    // region custom key
+
+    @Test
+    fun `boolean with explicit key uses that key in prefs`() {
+        class Holder {
+            var flag: Boolean by prefs.delegates.boolean(default = false, key = "my_custom_key")
+        }
+        val h = Holder()
+        h.flag = true
+        assertThat(prefs.getBoolean("my_custom_key", false)).isTrue()
+    }
+
+    // endregion
+}

--- a/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
@@ -26,7 +26,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class SettingsRepositoryTest {
     private lateinit var repo: SettingsRepository
 

--- a/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
@@ -16,6 +16,7 @@
 package de.lemke.commonutils.data
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import de.lemke.commonutils.SaveLocation
@@ -28,15 +29,18 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [36])
 class SettingsRepositoryTest {
+    private lateinit var prefs: SharedPreferences
     private lateinit var repo: SettingsRepository
 
     @Before
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val prefs = ctx.getSharedPreferences("settings_test", Context.MODE_PRIVATE)
+        prefs = ctx.getSharedPreferences("settings_test", Context.MODE_PRIVATE)
         prefs.edit().clear().apply()
         repo = SettingsRepository(prefs)
     }
+
+    private fun reload() = SettingsRepository(prefs)
 
     @Test
     fun `darkMode defaults to false`() {
@@ -74,55 +78,55 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `lastVersionCode round-trips written value`() {
-        repo.lastVersionCode = 42
-        assertThat(repo.lastVersionCode).isEqualTo(42)
-    }
-
-    @Test
-    fun `darkMode round-trips written value`() {
-        repo.darkMode = true
-        assertThat(repo.darkMode).isTrue()
-    }
-
-    @Test
-    fun `search round-trips written value`() {
-        repo.search = "hello"
-        assertThat(repo.search).isEqualTo("hello")
-    }
-
-    @Test
     fun `imageSaveLocation defaults to SaveLocation default`() {
         assertThat(repo.imageSaveLocation).isEqualTo(SaveLocation.default)
     }
 
     @Test
+    fun `lastVersionCode round-trips written value`() {
+        repo.lastVersionCode = 42
+        assertThat(reload().lastVersionCode).isEqualTo(42)
+    }
+
+    @Test
+    fun `darkMode round-trips written value`() {
+        repo.darkMode = true
+        assertThat(reload().darkMode).isTrue()
+    }
+
+    @Test
+    fun `search round-trips written value`() {
+        repo.search = "hello"
+        assertThat(reload().search).isEqualTo("hello")
+    }
+
+    @Test
     fun `imageSaveLocation round-trips DOWNLOADS`() {
         repo.imageSaveLocation = SaveLocation.DOWNLOADS
-        assertThat(repo.imageSaveLocation).isEqualTo(SaveLocation.DOWNLOADS)
+        assertThat(reload().imageSaveLocation).isEqualTo(SaveLocation.DOWNLOADS)
     }
 
     @Test
     fun `autoDarkMode round-trips false`() {
         repo.autoDarkMode = false
-        assertThat(repo.autoDarkMode).isFalse()
+        assertThat(reload().autoDarkMode).isFalse()
     }
 
     @Test
     fun `devModeEnabled round-trips true`() {
         repo.devModeEnabled = true
-        assertThat(repo.devModeEnabled).isTrue()
+        assertThat(reload().devModeEnabled).isTrue()
     }
 
     @Test
     fun `acceptedTosVersion round-trips written value`() {
         repo.acceptedTosVersion = 3
-        assertThat(repo.acceptedTosVersion).isEqualTo(3)
+        assertThat(reload().acceptedTosVersion).isEqualTo(3)
     }
 
     @Test
     fun `lastVersionName round-trips written value`() {
         repo.lastVersionName = "2.5.0"
-        assertThat(repo.lastVersionName).isEqualTo("2.5.0")
+        assertThat(reload().lastVersionName).isEqualTo("2.5.0")
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import de.lemke.commonutils.SaveLocation
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SettingsRepositoryTest {
+    private lateinit var repo: SettingsRepository
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = ctx.getSharedPreferences("settings_test", Context.MODE_PRIVATE)
+        prefs.edit().clear().apply()
+        repo = SettingsRepository(prefs)
+    }
+
+    @Test
+    fun `darkMode defaults to false`() {
+        assertThat(repo.darkMode).isFalse()
+    }
+
+    @Test
+    fun `autoDarkMode defaults to true`() {
+        assertThat(repo.autoDarkMode).isTrue()
+    }
+
+    @Test
+    fun `lastVersionCode defaults to -1`() {
+        assertThat(repo.lastVersionCode).isEqualTo(-1)
+    }
+
+    @Test
+    fun `lastVersionName defaults to 0_0_0`() {
+        assertThat(repo.lastVersionName).isEqualTo("0.0.0")
+    }
+
+    @Test
+    fun `acceptedTosVersion defaults to -1`() {
+        assertThat(repo.acceptedTosVersion).isEqualTo(-1)
+    }
+
+    @Test
+    fun `devModeEnabled defaults to false`() {
+        assertThat(repo.devModeEnabled).isFalse()
+    }
+
+    @Test
+    fun `search defaults to empty string`() {
+        assertThat(repo.search).isEmpty()
+    }
+
+    @Test
+    fun `lastVersionCode round-trips written value`() {
+        repo.lastVersionCode = 42
+        assertThat(repo.lastVersionCode).isEqualTo(42)
+    }
+
+    @Test
+    fun `darkMode round-trips written value`() {
+        repo.darkMode = true
+        assertThat(repo.darkMode).isTrue()
+    }
+
+    @Test
+    fun `search round-trips written value`() {
+        repo.search = "hello"
+        assertThat(repo.search).isEqualTo("hello")
+    }
+
+    @Test
+    fun `imageSaveLocation defaults to SaveLocation default`() {
+        assertThat(repo.imageSaveLocation).isEqualTo(SaveLocation.default)
+    }
+
+    @Test
+    fun `imageSaveLocation round-trips DOWNLOADS`() {
+        repo.imageSaveLocation = SaveLocation.DOWNLOADS
+        assertThat(repo.imageSaveLocation).isEqualTo(SaveLocation.DOWNLOADS)
+    }
+
+    @Test
+    fun `autoDarkMode round-trips false`() {
+        repo.autoDarkMode = false
+        assertThat(repo.autoDarkMode).isFalse()
+    }
+
+    @Test
+    fun `devModeEnabled round-trips true`() {
+        repo.devModeEnabled = true
+        assertThat(repo.devModeEnabled).isTrue()
+    }
+
+    @Test
+    fun `acceptedTosVersion round-trips written value`() {
+        repo.acceptedTosVersion = 3
+        assertThat(repo.acceptedTosVersion).isEqualTo(3)
+    }
+
+    @Test
+    fun `lastVersionName round-trips written value`() {
+        repo.lastVersionName = "2.5.0"
+        assertThat(repo.lastVersionName).isEqualTo("2.5.0")
+    }
+}

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/DimmingViewTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/DimmingViewTest.kt
@@ -26,7 +26,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class DimmingViewTest {
     @Test
     fun `default constructor sets MATCH_PARENT layout params`() {

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/InfoBottomSheetTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/InfoBottomSheetTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class InfoBottomSheetTest {
     // newInstance is private on the companion object; access via reflection so tests
     // cover argument-packing without needing a themed Activity to show the dialog.

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/NoEntryViewTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/NoEntryViewTest.kt
@@ -25,7 +25,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class NoEntryViewTest {
     private fun view() = NoEntryView(ApplicationProvider.getApplicationContext())
 

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/TouchBlockingViewTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/TouchBlockingViewTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [36])
 class TouchBlockingViewTest {
     @Test
     fun `clickable by default`() {


### PR DESCRIPTION
## Summary

- New JUnit 5 tests for zero-dependency pure logic: `URLUtils` (4 string extensions), `ExportUtils.toSafeFileName` (invariants), `SaveLocation` companion (`fromStringOrDefault`, `entryValues`, `default`), and `AppStart` computed properties (`isFirstTime`, `isFirstTimeVersion`, `tosAccepted`, `shouldShowOOBE`, `versionThresholdPassed`)
- New Robolectric tests: `SaveLocation.toLocalizedString`/`getLocalizedEntries`, `DelegatesAdvanced` all 8 delegate types with round-trip + default checks, `SettingsRepository` all fields
- Kover `verify` block added with `minBound(12)` — actual coverage ~13%; 15% projection in plan was optimistic (activities are OneUI-dependent, not testable in JVM)

## Test plan

- [ ] `./gradlew testDebugUnitTest` — all tests green
- [ ] `./gradlew koverVerify` — 12% floor enforced
- [ ] `./gradlew spotlessCheck detekt assembleRelease` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for app startup behavior validation
  * Added tests for filename generation utilities
  * Added tests for URL handling utilities
  * Added tests for save location functionality
  * Added tests for preference storage and settings management

* **Chores**
  * Updated code coverage configuration to enforce minimum coverage standards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lemkinator/common-utils/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->