### PR TITLE
test: migrate all tests to Kotest 6 + Robolectric JUnit5 (Step 13.5)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,9 @@ common-utils = "0.9.23"
 aboutlibraries = "14.2.0"
 coroutines = "1.11.0"
 kover = "0.9.8"
+kotest = "6.1.11"
+kotest-robolectric = "0.9.0"
 mockk = "1.14.9"
-truth = "1.4.5"
 turbine = "1.2.1"
 hilt = "2.59.2"
 ksp = "2.3.8"
@@ -47,12 +48,13 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-extensions-robolectric = { module = "tech.apter.junit5.jupiter:robolectric-extension", version.ref = "kotest-robolectric" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-junit-vintage-engine = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junit-jupiter" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
 oneui-design = { module = "io.github.tribalfs:oneui-design", version.ref = "oneui-design" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 app-update = { module = "com.google.android.play:app-update", version.ref = "app-update" }
 core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-jupiter" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -35,7 +35,10 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
-            all { it.useJUnitPlatform() }
+            all {
+                it.useJUnitPlatform()
+                it.jvmArgs("-Djunit.platform.launcher.interceptors.enabled=true")
+            }
         }
     }
     packaging {
@@ -96,13 +99,13 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.konsist)
-    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.extensions.robolectric)
     testRuntimeOnly(libs.junit.jupiter.engine)
-    testRuntimeOnly(libs.junit.vintage.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.mockk)
     testImplementation(libs.turbine)
-    testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)

--- a/lib/src/test/AndroidManifest.xml
+++ b/lib/src/test/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity
+            android:name="androidx.appcompat.app.AppCompatActivity"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+    </application>
+</manifest>

--- a/lib/src/test/java/de/lemke/commonutils/ArchitectureTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ArchitectureTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Leonard Lemke
+ * Copyright 2024-2026 Leonard Lemke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,31 +17,26 @@ package de.lemke.commonutils
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withPackage
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeFalse
 
-class ArchitectureTest {
-    private val scope = Konsist.scopeFromProduction()
+class ArchitectureTest : ShouldSpec() {
+    private val codeScope = Konsist.scopeFromProduction()
 
-    @Test
-    fun `ui activities do not depend on widget internals`() {
-        scope.files
-            .withPackage("de.lemke.commonutils.ui.activity..")
-            .forEach { file ->
-                assertFalse(file.imports.any { it.name.contains(".widget.internal.") }) {
-                    "${file.name} imports widget internals"
+    init {
+        should("ui activities not depend on widget internals") {
+            codeScope.files
+                .withPackage("de.lemke.commonutils.ui.activity..")
+                .forEach { file ->
+                    file.imports.any { it.name.contains(".widget.internal.") }.shouldBeFalse()
                 }
-            }
-    }
-
-    @Test
-    fun `data layer does not depend on ui`() {
-        scope.files
-            .withPackage("de.lemke.commonutils.data..")
-            .forEach { file ->
-                assertFalse(file.imports.any { it.name.startsWith("de.lemke.commonutils.ui.") }) {
-                    "${file.name} in data layer imports UI"
+        }
+        should("data layer not depend on ui") {
+            codeScope.files
+                .withPackage("de.lemke.commonutils.data..")
+                .forEach { file ->
+                    file.imports.any { it.name.startsWith("de.lemke.commonutils.ui.") }.shouldBeFalse()
                 }
-            }
+        }
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/ArchitectureTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ArchitectureTest.kt
@@ -17,6 +17,7 @@ package de.lemke.commonutils
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withPackage
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 
@@ -28,14 +29,18 @@ class ArchitectureTest : ShouldSpec() {
             codeScope.files
                 .withPackage("de.lemke.commonutils.ui.activity..")
                 .forEach { file ->
-                    file.imports.any { it.name.contains(".widget.internal.") }.shouldBeFalse()
+                    withClue("${file.path} imports widget internals") {
+                        file.imports.any { it.name.contains(".widget.internal.") }.shouldBeFalse()
+                    }
                 }
         }
         should("data layer not depend on ui") {
             codeScope.files
                 .withPackage("de.lemke.commonutils.data..")
                 .forEach { file ->
-                    file.imports.any { it.name.startsWith("de.lemke.commonutils.ui.") }.shouldBeFalse()
+                    withClue("${file.path} imports ui layer") {
+                        file.imports.any { it.name.startsWith("de.lemke.commonutils.ui.") }.shouldBeFalse()
+                    }
                 }
         }
     }

--- a/lib/src/test/java/de/lemke/commonutils/BasicUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/BasicUtilsTest.kt
@@ -16,113 +16,86 @@
 package de.lemke.commonutils
 
 import android.os.Bundle
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 
-class BasicUtilsTest {
-    // region saveSearchAndActionMode
-
-    @Test
-    fun `saveSearchAndActionMode stores search mode flag when true`() {
-        val bundle = mockk<Bundle>(relaxed = true)
-        bundle.saveSearchAndActionMode(isSearchMode = true)
-        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, true) }
+class BasicUtilsTest : ShouldSpec({
+    context("saveSearchAndActionMode") {
+        should("store search mode flag when true") {
+            val bundle = mockk<Bundle>(relaxed = true)
+            bundle.saveSearchAndActionMode(isSearchMode = true)
+            verify { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, true) }
+        }
+        should("omit search mode flag when false") {
+            val bundle = mockk<Bundle>(relaxed = true)
+            bundle.saveSearchAndActionMode(isSearchMode = false)
+            verify(exactly = 0) { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, any()) }
+        }
+        should("store action mode flag and IDs when true") {
+            val bundle = mockk<Bundle>(relaxed = true)
+            val ids = setOf(1L, 2L, 3L)
+            bundle.saveSearchAndActionMode(isActionMode = true, selectedIds = ids)
+            verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
+            verify { bundle.putLongArray(COMMONUTILS_KEY_SELECTED_IDS, match { it.contentEquals(ids.toLongArray()) }) }
+        }
+        should("omit action mode data when false") {
+            val bundle = mockk<Bundle>(relaxed = true)
+            bundle.saveSearchAndActionMode(isActionMode = false)
+            verify(exactly = 0) { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, any()) }
+            verify(exactly = 0) { bundle.putLongArray(any(), any()) }
+        }
+        should("store both modes simultaneously") {
+            val bundle = mockk<Bundle>(relaxed = true)
+            bundle.saveSearchAndActionMode(isSearchMode = true, isActionMode = true, selectedIds = setOf(42L))
+            verify { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, true) }
+            verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
+        }
     }
-
-    @Test
-    fun `saveSearchAndActionMode omits search mode flag when false`() {
-        val bundle = mockk<Bundle>(relaxed = true)
-        bundle.saveSearchAndActionMode(isSearchMode = false)
-        verify(exactly = 0) { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, any()) }
+    context("restoreSearchAndActionMode") {
+        should("call onSearchMode when flag set") {
+            val bundle = mockk<Bundle>()
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns true
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns false
+            var called = false
+            bundle.restoreSearchAndActionMode(onSearchMode = { called = true })
+            called.shouldBeTrue()
+        }
+        should("skip onSearchMode when flag not set") {
+            val bundle = mockk<Bundle>()
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns false
+            var called = false
+            bundle.restoreSearchAndActionMode(onSearchMode = { called = true })
+            called.shouldBeFalse()
+        }
+        should("call onActionMode with IDs") {
+            val bundle = mockk<Bundle>()
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns true
+            every { bundle.getLongArray(COMMONUTILS_KEY_SELECTED_IDS) } returns longArrayOf(10L, 20L)
+            var receivedIds: Set<Long>? = null
+            bundle.restoreSearchAndActionMode(onActionMode = { receivedIds = it })
+            receivedIds shouldBe setOf(10L, 20L)
+        }
+        should("pass empty set when getLongArray returns null") {
+            val bundle = mockk<Bundle>()
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
+            every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns true
+            every { bundle.getLongArray(COMMONUTILS_KEY_SELECTED_IDS) } returns null
+            var receivedIds: Set<Long>? = null
+            bundle.restoreSearchAndActionMode(onActionMode = { receivedIds = it })
+            receivedIds shouldBe emptySet()
+        }
+        should("call bundleIsNull when receiver is null") {
+            val bundle: Bundle? = null
+            var called = false
+            bundle.restoreSearchAndActionMode(bundleIsNull = { called = true })
+            called.shouldBeTrue()
+        }
     }
-
-    @Test
-    fun `saveSearchAndActionMode stores action mode flag and IDs when true`() {
-        val bundle = mockk<Bundle>(relaxed = true)
-        val ids = setOf(1L, 2L, 3L)
-        bundle.saveSearchAndActionMode(isActionMode = true, selectedIds = ids)
-        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
-        verify { bundle.putLongArray(COMMONUTILS_KEY_SELECTED_IDS, match { it.contentEquals(ids.toLongArray()) }) }
-    }
-
-    @Test
-    fun `saveSearchAndActionMode omits action mode data when false`() {
-        val bundle = mockk<Bundle>(relaxed = true)
-        bundle.saveSearchAndActionMode(isActionMode = false)
-        verify(exactly = 0) { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, any()) }
-        verify(exactly = 0) { bundle.putLongArray(any(), any()) }
-    }
-
-    @Test
-    fun `saveSearchAndActionMode stores both modes simultaneously`() {
-        val bundle = mockk<Bundle>(relaxed = true)
-        bundle.saveSearchAndActionMode(isSearchMode = true, isActionMode = true, selectedIds = setOf(42L))
-        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE, true) }
-        verify { bundle.putBoolean(COMMONUTILS_KEY_IS_ACTION_MODE, true) }
-    }
-
-    // endregion
-
-    // region restoreSearchAndActionMode
-
-    @Test
-    fun `restoreSearchAndActionMode calls onSearchMode when flag set`() {
-        val bundle = mockk<Bundle>()
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns true
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns false
-
-        var called = false
-        bundle.restoreSearchAndActionMode(onSearchMode = { called = true })
-        assertTrue(called)
-    }
-
-    @Test
-    fun `restoreSearchAndActionMode skips onSearchMode when flag not set`() {
-        val bundle = mockk<Bundle>()
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns false
-
-        var called = false
-        bundle.restoreSearchAndActionMode(onSearchMode = { called = true })
-        assertFalse(called)
-    }
-
-    @Test
-    fun `restoreSearchAndActionMode calls onActionMode with IDs`() {
-        val bundle = mockk<Bundle>()
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns true
-        every { bundle.getLongArray(COMMONUTILS_KEY_SELECTED_IDS) } returns longArrayOf(10L, 20L)
-
-        var receivedIds: Set<Long>? = null
-        bundle.restoreSearchAndActionMode(onActionMode = { receivedIds = it })
-        assertEquals(setOf(10L, 20L), receivedIds)
-    }
-
-    @Test
-    fun `restoreSearchAndActionMode passes empty set when getLongArray returns null`() {
-        val bundle = mockk<Bundle>()
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_SEARCH_MODE) } returns false
-        every { bundle.getBoolean(COMMONUTILS_KEY_IS_ACTION_MODE) } returns true
-        every { bundle.getLongArray(COMMONUTILS_KEY_SELECTED_IDS) } returns null
-
-        var receivedIds: Set<Long>? = null
-        bundle.restoreSearchAndActionMode(onActionMode = { receivedIds = it })
-        assertEquals(emptySet<Long>(), receivedIds)
-    }
-
-    @Test
-    fun `restoreSearchAndActionMode calls bundleIsNull when receiver is null`() {
-        var called = false
-        val bundle: Bundle? = null
-        bundle.restoreSearchAndActionMode(bundleIsNull = { called = true })
-        assertTrue(called)
-    }
-
-    // endregion
-}
+})

--- a/lib/src/test/java/de/lemke/commonutils/CheckAppStartTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/CheckAppStartTest.kt
@@ -15,11 +15,12 @@
  */
 package de.lemke.commonutils
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.string.shouldContain
 
-class CheckAppStartTest {
+class CheckAppStartTest : ShouldSpec() {
     private fun appStart(
         versionCode: Int = 10,
         versionName: String = "1.0",
@@ -35,120 +36,72 @@ class CheckAppStartTest {
             },
     ) = AppStart(result, versionCode, versionName, lastVersionCode, lastVersionName, tosVersion, acceptedTosVersion)
 
-    // region isFirstTime
-
-    @Test
-    fun `isFirstTime is true when lastVersionCode is -1`() {
-        assertTrue(appStart(lastVersionCode = -1).isFirstTime)
+    init {
+        context("isFirstTime") {
+            should("be true when lastVersionCode is -1") {
+                appStart(lastVersionCode = -1).isFirstTime.shouldBeTrue()
+            }
+            should("be false when lastVersionCode is not -1") {
+                appStart(lastVersionCode = 5).isFirstTime.shouldBeFalse()
+            }
+        }
+        context("isFirstTimeVersion") {
+            should("be true when lastVersionCode less than versionCode") {
+                appStart(versionCode = 10, lastVersionCode = 9).isFirstTimeVersion.shouldBeTrue()
+            }
+            should("be false when codes are equal") {
+                appStart(versionCode = 10, lastVersionCode = 10).isFirstTimeVersion.shouldBeFalse()
+            }
+            should("be false when lastVersionCode greater") {
+                appStart(versionCode = 9, lastVersionCode = 10).isFirstTimeVersion.shouldBeFalse()
+            }
+        }
+        context("tosAccepted") {
+            should("be true when acceptedTosVersion equals tosVersion") {
+                appStart(tosVersion = 2, acceptedTosVersion = 2).tosAccepted.shouldBeTrue()
+            }
+            should("be true when acceptedTosVersion exceeds tosVersion") {
+                appStart(tosVersion = 1, acceptedTosVersion = 3).tosAccepted.shouldBeTrue()
+            }
+            should("be false when acceptedTosVersion below tosVersion") {
+                appStart(tosVersion = 2, acceptedTosVersion = 1).tosAccepted.shouldBeFalse()
+            }
+        }
+        context("shouldShowOOBE") {
+            should("be true on first install") {
+                appStart(lastVersionCode = -1, tosVersion = 1, acceptedTosVersion = 1).shouldShowOOBE.shouldBeTrue()
+            }
+            should("be true when TOS not accepted") {
+                appStart(lastVersionCode = 5, tosVersion = 2, acceptedTosVersion = 1).shouldShowOOBE.shouldBeTrue()
+            }
+            should("be false when returning user with accepted TOS") {
+                appStart(lastVersionCode = 5, tosVersion = 1, acceptedTosVersion = 1).shouldShowOOBE.shouldBeFalse()
+            }
+        }
+        context("versionThresholdPassed") {
+            should("be true when threshold within upgrade range") {
+                appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(7).shouldBeTrue()
+            }
+            should("be false when threshold below range") {
+                appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(4).shouldBeFalse()
+            }
+            should("be true when threshold equals lastVersionCode (inclusive start)") {
+                appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(5).shouldBeTrue()
+            }
+            should("be false when threshold equals versionCode (exclusive end)") {
+                appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(10).shouldBeFalse()
+            }
+            should("be false when threshold above range") {
+                appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(11).shouldBeFalse()
+            }
+        }
+        context("toString") {
+            should("include versionCode") {
+                appStart(versionCode = 42).toString() shouldContain "42"
+            }
+            should("include versionName") {
+                appStart(versionName = "2.3.4").toString() shouldContain "2.3.4"
+            }
+        }
     }
-
-    @Test
-    fun `isFirstTime is false when lastVersionCode is not -1`() {
-        assertFalse(appStart(lastVersionCode = 5).isFirstTime)
-    }
-
-    // endregion
-
-    // region isFirstTimeVersion
-
-    @Test
-    fun `isFirstTimeVersion is true when lastVersionCode less than versionCode`() {
-        assertTrue(appStart(versionCode = 10, lastVersionCode = 9).isFirstTimeVersion)
-    }
-
-    @Test
-    fun `isFirstTimeVersion is false when codes are equal`() {
-        assertFalse(appStart(versionCode = 10, lastVersionCode = 10).isFirstTimeVersion)
-    }
-
-    @Test
-    fun `isFirstTimeVersion is false when lastVersionCode greater`() {
-        assertFalse(appStart(versionCode = 9, lastVersionCode = 10).isFirstTimeVersion)
-    }
-
-    // endregion
-
-    // region tosAccepted
-
-    @Test
-    fun `tosAccepted is true when acceptedTosVersion equals tosVersion`() {
-        assertTrue(appStart(tosVersion = 2, acceptedTosVersion = 2).tosAccepted)
-    }
-
-    @Test
-    fun `tosAccepted is true when acceptedTosVersion exceeds tosVersion`() {
-        assertTrue(appStart(tosVersion = 1, acceptedTosVersion = 3).tosAccepted)
-    }
-
-    @Test
-    fun `tosAccepted is false when acceptedTosVersion below tosVersion`() {
-        assertFalse(appStart(tosVersion = 2, acceptedTosVersion = 1).tosAccepted)
-    }
-
-    // endregion
-
-    // region shouldShowOOBE
-
-    @Test
-    fun `shouldShowOOBE is true on first install`() {
-        assertTrue(appStart(lastVersionCode = -1, tosVersion = 1, acceptedTosVersion = 1).shouldShowOOBE)
-    }
-
-    @Test
-    fun `shouldShowOOBE is true when TOS not accepted`() {
-        assertTrue(appStart(lastVersionCode = 5, tosVersion = 2, acceptedTosVersion = 1).shouldShowOOBE)
-    }
-
-    @Test
-    fun `shouldShowOOBE is false when returning user with accepted TOS`() {
-        assertFalse(appStart(lastVersionCode = 5, tosVersion = 1, acceptedTosVersion = 1).shouldShowOOBE)
-    }
-
-    // endregion
-
-    // region versionThresholdPassed
-
-    @Test
-    fun `versionThresholdPassed is true when threshold within upgrade range`() {
-        // lastVersionCode=5, versionCode=10 → range 5..<10
-        assertTrue(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(7))
-    }
-
-    @Test
-    fun `versionThresholdPassed is false when threshold below range`() {
-        assertFalse(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(4))
-    }
-
-    @Test
-    fun `versionThresholdPassed is true when threshold equals lastVersionCode (inclusive start)`() {
-        assertTrue(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(5))
-    }
-
-    @Test
-    fun `versionThresholdPassed is false when threshold equals versionCode (exclusive end)`() {
-        assertFalse(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(10))
-    }
-
-    @Test
-    fun `versionThresholdPassed is false when threshold above range`() {
-        assertFalse(appStart(versionCode = 10, lastVersionCode = 5).versionThresholdPassed(11))
-    }
-
-    // endregion
-
-    // region toString
-
-    @Test
-    fun `toString includes versionCode`() {
-        val s = appStart(versionCode = 42).toString()
-        assertTrue(s.contains("42"))
-    }
-
-    @Test
-    fun `toString includes versionName`() {
-        val s = appStart(versionName = "2.3.4").toString()
-        assertTrue(s.contains("2.3.4"))
-    }
-
-    // endregion
 }

--- a/lib/src/test/java/de/lemke/commonutils/CoroutineContractsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/CoroutineContractsTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import app.cash.turbine.test
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+
+class CoroutineContractsTest : ShouldSpec({
+    context("StateFlow") {
+        should("emit initial value on subscription") {
+            runTest {
+                MutableStateFlow(42).test {
+                    awaitItem() shouldBe 42
+                    cancel()
+                }
+            }
+        }
+        should("emit subsequent updates") {
+            runTest {
+                val flow = MutableStateFlow(0)
+                flow.test {
+                    awaitItem() // consume initial
+                    flow.value = 7
+                    awaitItem() shouldBe 7
+                    cancel()
+                }
+            }
+        }
+    }
+    context("Channel") {
+        should("deliver buffered items via receiveAsFlow") {
+            runTest {
+                val channel = Channel<String>(Channel.BUFFERED)
+                launch {
+                    channel.send("a")
+                    channel.send("b")
+                    channel.close()
+                }
+                channel.receiveAsFlow().test {
+                    awaitItem() shouldBe "a"
+                    awaitItem() shouldBe "b"
+                    awaitComplete()
+                }
+            }
+        }
+    }
+})

--- a/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
@@ -17,8 +17,8 @@ package de.lemke.commonutils
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldMatch
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldNotStartWith
 
@@ -28,7 +28,7 @@ class ExportUtilsTest : ShouldSpec({
     }
     should("toSafeFileName contain only alphanumeric and underscores before extension") {
         val result = "my photo".toSafeFileName(".png")
-        result.removeSuffix(".png").matches("[a-zA-Z0-9_]+".toRegex()).shouldBeTrue()
+        result.removeSuffix(".png") shouldMatch "[a-zA-Z0-9_]+"
     }
     should("toSafeFileName remove https scheme") {
         "https://example.com".toSafeFileName(".png") shouldNotContain "https"
@@ -36,7 +36,7 @@ class ExportUtilsTest : ShouldSpec({
     should("toSafeFileName not start with http___ after http scheme sanitization") {
         val result = "http://example.com".toSafeFileName(".png")
         result.shouldNotStartWith("http___")
-        result.removeSuffix(".png").matches("[a-zA-Z0-9_]+".toRegex()).shouldBeTrue()
+        result.removeSuffix(".png") shouldMatch "[a-zA-Z0-9_]+"
     }
     should("toSafeFileName have no leading underscores before extension") {
         "  leading spaces".toSafeFileName(".png").startsWith("_").shouldBeFalse()
@@ -47,9 +47,7 @@ class ExportUtilsTest : ShouldSpec({
     should("toSafeFileName replace special characters with underscores") {
         "file@name!test"
             .toSafeFileName(".png")
-            .removeSuffix(".png")
-            .matches("[a-zA-Z0-9_]+".toRegex())
-            .shouldBeTrue()
+            .removeSuffix(".png") shouldMatch "[a-zA-Z0-9_]+"
     }
     should("toSafeFileName preserve appended extension literally") {
         "test".toSafeFileName(".jpg") shouldEndWith ".jpg"

--- a/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ExportUtilsTest.kt
@@ -15,64 +15,43 @@
  */
 package de.lemke.commonutils
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldNotStartWith
 
-class ExportUtilsTest {
-    @Test
-    fun `toSafeFileName ends with given extension`() {
+class ExportUtilsTest : ShouldSpec({
+    should("toSafeFileName end with given extension") {
+        "my photo".toSafeFileName(".png") shouldEndWith ".png"
+    }
+    should("toSafeFileName contain only alphanumeric and underscores before extension") {
         val result = "my photo".toSafeFileName(".png")
-        assertTrue(result.endsWith(".png"))
+        result.removeSuffix(".png").matches("[a-zA-Z0-9_]+".toRegex()).shouldBeTrue()
     }
-
-    @Test
-    fun `toSafeFileName contains only alphanumeric and underscores before extension`() {
-        val result = "my photo".toSafeFileName(".png")
-        val base = result.removeSuffix(".png")
-        assertTrue(base.matches("[a-zA-Z0-9_]+".toRegex())) {
-            "Base '$base' contains disallowed characters"
-        }
+    should("toSafeFileName remove https scheme") {
+        "https://example.com".toSafeFileName(".png") shouldNotContain "https"
     }
-
-    @Test
-    fun `toSafeFileName removes https scheme`() {
-        val result = "https://example.com".toSafeFileName(".png")
-        assertFalse(result.contains("https"))
-    }
-
-    @Test
-    fun `toSafeFileName does not remove http scheme (only https is stripped)`() {
-        // Implementation only strips "https://" — "http://" becomes "http___"
+    should("toSafeFileName not start with http___ after http scheme sanitization") {
         val result = "http://example.com".toSafeFileName(".png")
-        assertFalse(result.startsWith("http___"), "http:// should produce safe chars, not 'http___'")
-        // Base must still be alphanumeric+undersscores only
-        val base = result.removeSuffix(".png")
-        assertTrue(base.matches("[a-zA-Z0-9_]+".toRegex()))
+        result.shouldNotStartWith("http___")
+        result.removeSuffix(".png").matches("[a-zA-Z0-9_]+".toRegex()).shouldBeTrue()
     }
-
-    @Test
-    fun `toSafeFileName has no leading underscores before extension`() {
-        val result = "  leading spaces".toSafeFileName(".png")
-        assertFalse(result.startsWith("_"))
+    should("toSafeFileName have no leading underscores before extension") {
+        "  leading spaces".toSafeFileName(".png").startsWith("_").shouldBeFalse()
     }
-
-    @Test
-    fun `toSafeFileName has no consecutive underscores`() {
-        val result = "hello   world".toSafeFileName(".png")
-        assertFalse(result.contains("__"))
+    should("toSafeFileName have no consecutive underscores") {
+        "hello   world".toSafeFileName(".png") shouldNotContain "__"
     }
-
-    @Test
-    fun `toSafeFileName replaces special characters with underscores`() {
-        val result = "file@name!test".toSafeFileName(".png")
-        val base = result.removeSuffix(".png")
-        assertTrue(base.matches("[a-zA-Z0-9_]+".toRegex()))
+    should("toSafeFileName replace special characters with underscores") {
+        "file@name!test"
+            .toSafeFileName(".png")
+            .removeSuffix(".png")
+            .matches("[a-zA-Z0-9_]+".toRegex())
+            .shouldBeTrue()
     }
-
-    @Test
-    fun `toSafeFileName appended extension is preserved literally`() {
-        val result = "test".toSafeFileName(".jpg")
-        assertTrue(result.endsWith(".jpg"))
+    should("toSafeFileName preserve appended extension literally") {
+        "test".toSafeFileName(".jpg") shouldEndWith ".jpg"
     }
-}
+})

--- a/lib/src/test/java/de/lemke/commonutils/LifecycleCollectorsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/LifecycleCollectorsTest.kt
@@ -17,7 +17,6 @@ package de.lemke.commonutils
 
 import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,24 +41,21 @@ class LifecycleCollectorsTest {
                 .get()
         val idle = { Shadows.shadowOf(Looper.getMainLooper()).idle() }
 
-        // collectState: initial value
         val stateFlow = MutableStateFlow(42)
         val stateCollected = mutableListOf<Int>()
         activity.collectState(stateFlow) { stateCollected.add(it) }
         idle()
-        stateCollected.first() shouldBe 42
+        stateCollected shouldBe listOf(42)
 
-        // collectState: subsequent emission
         stateFlow.value = 99
         idle()
-        stateCollected shouldContain 99
+        stateCollected shouldBe listOf(42, 99)
 
-        // collectEvents: buffered channel item
         val channel = Channel<String>(Channel.BUFFERED)
         val eventCollected = mutableListOf<String>()
         channel.trySend("hello")
         activity.collectEvents(channel) { eventCollected.add(it) }
         idle()
-        eventCollected.first() shouldBe "hello"
+        eventCollected shouldBe listOf("hello")
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/LifecycleCollectorsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/LifecycleCollectorsTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.commonutils
+
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+@Config(sdk = [34])
+class LifecycleCollectorsTest {
+    @Test
+    fun `lifecycle collectors pin contract`() {
+        val activity =
+            Robolectric
+                .buildActivity(AppCompatActivity::class.java)
+                .create()
+                .start()
+                .resume()
+                .get()
+        val idle = { Shadows.shadowOf(Looper.getMainLooper()).idle() }
+
+        // collectState: initial value
+        val stateFlow = MutableStateFlow(42)
+        val stateCollected = mutableListOf<Int>()
+        activity.collectState(stateFlow) { stateCollected.add(it) }
+        idle()
+        stateCollected.first() shouldBe 42
+
+        // collectState: subsequent emission
+        stateFlow.value = 99
+        idle()
+        stateCollected shouldContain 99
+
+        // collectEvents: buffered channel item
+        val channel = Channel<String>(Channel.BUFFERED)
+        val eventCollected = mutableListOf<String>()
+        channel.trySend("hello")
+        activity.collectEvents(channel) { eventCollected.add(it) }
+        idle()
+        eventCollected.first() shouldBe "hello"
+    }
+}

--- a/lib/src/test/java/de/lemke/commonutils/MainDispatcherListener.kt
+++ b/lib/src/test/java/de/lemke/commonutils/MainDispatcherListener.kt
@@ -17,20 +17,27 @@
 
 package de.lemke.commonutils
 
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.BeforeTestListener
+import io.kotest.core.test.TestCase
+import io.kotest.engine.test.TestResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtensionContext
 
-class MainDispatcherExtension(
-    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
-) : BeforeEachCallback, AfterEachCallback {
-    override fun beforeEach(context: ExtensionContext) = Dispatchers.setMain(testDispatcher)
+class MainDispatcherListener : BeforeTestListener, AfterTestListener {
+    private val testDispatcher = UnconfinedTestDispatcher()
 
-    override fun afterEach(context: ExtensionContext) = Dispatchers.resetMain()
+    override suspend fun beforeTest(testCase: TestCase) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override suspend fun afterTest(
+        testCase: TestCase,
+        result: TestResult,
+    ) {
+        Dispatchers.resetMain()
+    }
 }

--- a/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/SaveLocationRobolectricTest.kt
@@ -17,39 +17,52 @@ package de.lemke.commonutils
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class SaveLocationRobolectricTest {
     private val ctx: Context get() = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `toLocalizedString returns non-blank for CUSTOM`() {
-        assertThat(SaveLocation.CUSTOM.toLocalizedString(ctx).isNotBlank()).isTrue()
+        SaveLocation.CUSTOM
+            .toLocalizedString(ctx)
+            .isNotBlank()
+            .shouldBeTrue()
     }
 
     @Test
     fun `toLocalizedString returns non-blank for DOWNLOADS`() {
-        assertThat(SaveLocation.DOWNLOADS.toLocalizedString(ctx).isNotBlank()).isTrue()
+        SaveLocation.DOWNLOADS
+            .toLocalizedString(ctx)
+            .isNotBlank()
+            .shouldBeTrue()
     }
 
     @Test
     fun `toLocalizedString returns non-blank for PICTURES`() {
-        assertThat(SaveLocation.PICTURES.toLocalizedString(ctx).isNotBlank()).isTrue()
+        SaveLocation.PICTURES
+            .toLocalizedString(ctx)
+            .isNotBlank()
+            .shouldBeTrue()
     }
 
     @Test
     fun `toLocalizedString returns non-blank for DCIM`() {
-        assertThat(SaveLocation.DCIM.toLocalizedString(ctx).isNotBlank()).isTrue()
+        SaveLocation.DCIM
+            .toLocalizedString(ctx)
+            .isNotBlank()
+            .shouldBeTrue()
     }
 
     @Test
     fun `getLocalizedEntries returns 4 entries`() {
-        assertThat(SaveLocation.getLocalizedEntries(ctx)).hasLength(4)
+        SaveLocation.getLocalizedEntries(ctx).size shouldBe 4
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/SaveLocationTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/SaveLocationTest.kt
@@ -15,65 +15,43 @@
  */
 package de.lemke.commonutils
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 
-class SaveLocationTest {
-    // region fromStringOrDefault
-
-    @Test
-    fun `fromStringOrDefault returns CUSTOM for CUSTOM string`() {
-        assertEquals(SaveLocation.CUSTOM, SaveLocation.fromStringOrDefault("CUSTOM"))
+class SaveLocationTest : ShouldSpec({
+    context("fromStringOrDefault") {
+        should("return CUSTOM for CUSTOM string") {
+            SaveLocation.fromStringOrDefault("CUSTOM") shouldBe SaveLocation.CUSTOM
+        }
+        should("return DOWNLOADS for DOWNLOADS string") {
+            SaveLocation.fromStringOrDefault("DOWNLOADS") shouldBe SaveLocation.DOWNLOADS
+        }
+        should("return PICTURES for PICTURES string") {
+            SaveLocation.fromStringOrDefault("PICTURES") shouldBe SaveLocation.PICTURES
+        }
+        should("return DCIM for DCIM string") {
+            SaveLocation.fromStringOrDefault("DCIM") shouldBe SaveLocation.DCIM
+        }
+        should("return default for null") {
+            SaveLocation.fromStringOrDefault(null) shouldBe SaveLocation.default
+        }
+        should("return default for unknown string") {
+            SaveLocation.fromStringOrDefault("UNKNOWN") shouldBe SaveLocation.default
+        }
+        should("be case-sensitive") {
+            SaveLocation.fromStringOrDefault("custom") shouldBe SaveLocation.default
+        }
     }
-
-    @Test
-    fun `fromStringOrDefault returns DOWNLOADS for DOWNLOADS string`() {
-        assertEquals(SaveLocation.DOWNLOADS, SaveLocation.fromStringOrDefault("DOWNLOADS"))
+    context("entryValues") {
+        should("contain all enum names in order") {
+            SaveLocation.entryValues.toList() shouldContainExactly
+                listOf("CUSTOM", "DOWNLOADS", "PICTURES", "DCIM")
+        }
     }
-
-    @Test
-    fun `fromStringOrDefault returns PICTURES for PICTURES string`() {
-        assertEquals(SaveLocation.PICTURES, SaveLocation.fromStringOrDefault("PICTURES"))
+    context("default") {
+        should("be CUSTOM") {
+            SaveLocation.default shouldBe SaveLocation.CUSTOM
+        }
     }
-
-    @Test
-    fun `fromStringOrDefault returns DCIM for DCIM string`() {
-        assertEquals(SaveLocation.DCIM, SaveLocation.fromStringOrDefault("DCIM"))
-    }
-
-    @Test
-    fun `fromStringOrDefault returns default for null`() {
-        assertEquals(SaveLocation.default, SaveLocation.fromStringOrDefault(null))
-    }
-
-    @Test
-    fun `fromStringOrDefault returns default for unknown string`() {
-        assertEquals(SaveLocation.default, SaveLocation.fromStringOrDefault("UNKNOWN"))
-    }
-
-    @Test
-    fun `fromStringOrDefault is case-sensitive`() {
-        assertEquals(SaveLocation.default, SaveLocation.fromStringOrDefault("custom"))
-    }
-
-    // endregion
-
-    // region entryValues
-
-    @Test
-    fun `entryValues contains all enum names`() {
-        assertArrayEquals(arrayOf("CUSTOM", "DOWNLOADS", "PICTURES", "DCIM"), SaveLocation.entryValues)
-    }
-
-    // endregion
-
-    // region default
-
-    @Test
-    fun `default is CUSTOM`() {
-        assertEquals(SaveLocation.CUSTOM, SaveLocation.default)
-    }
-
-    // endregion
-}
+})

--- a/lib/src/test/java/de/lemke/commonutils/URLUtilsTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/URLUtilsTest.kt
@@ -15,99 +15,61 @@
  */
 package de.lemke.commonutils
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
 
-class URLUtilsTest {
-    // region withHttps
-
-    @Test
-    fun `withHttps prepends https to bare domain`() {
-        assertEquals("https://example.com", "example.com".withHttps())
+class URLUtilsTest : ShouldSpec({
+    context("withHttps") {
+        should("prepend https to bare domain") {
+            "example.com".withHttps() shouldBe "https://example.com"
+        }
+        should("leave https URL unchanged") {
+            "https://example.com".withHttps() shouldBe "https://example.com"
+        }
+        should("leave http URL unchanged") {
+            "http://example.com".withHttps() shouldBe "http://example.com"
+        }
+        should("prepend https to path without scheme") {
+            "example.com/path".withHttps() shouldBe "https://example.com/path"
+        }
     }
-
-    @Test
-    fun `withHttps leaves https URL unchanged`() {
-        assertEquals("https://example.com", "https://example.com".withHttps())
+    context("withoutHttps") {
+        should("remove https scheme") {
+            "https://example.com".withoutHttps() shouldBe "example.com"
+        }
+        should("remove http scheme") {
+            "http://example.com".withoutHttps() shouldBe "example.com"
+        }
+        should("remove trailing slash") {
+            "https://example.com/".withoutHttps() shouldBe "example.com"
+        }
+        should("leave plain domain unchanged") {
+            "example.com".withoutHttps() shouldBe "example.com"
+        }
+        should("strip https then http from doubly-prefixed input") {
+            "https://http://example.com".withoutHttps() shouldBe "example.com"
+        }
     }
-
-    @Test
-    fun `withHttps leaves http URL unchanged`() {
-        assertEquals("http://example.com", "http://example.com".withHttps())
+    context("urlEncodeAmpersand") {
+        should("replace single ampersand") {
+            "a&b".urlEncodeAmpersand() shouldBe "a%26b"
+        }
+        should("replace multiple ampersands") {
+            "a&b&c".urlEncodeAmpersand() shouldBe "a%26b%26c"
+        }
+        should("leave string without ampersand unchanged") {
+            "hello".urlEncodeAmpersand() shouldBe "hello"
+        }
     }
-
-    @Test
-    fun `withHttps prepends https to path without scheme`() {
-        assertEquals("https://example.com/path", "example.com/path".withHttps())
+    context("urlEncode") {
+        should("encode space as plus") {
+            "hello world".urlEncode() shouldBe "hello+world"
+        }
+        should("encode special characters") {
+            "a&b".urlEncode() shouldBe "a%26b"
+        }
+        should("leave alphanumeric unchanged") {
+            "abc123".urlEncode() shouldBe "abc123"
+        }
     }
-
-    // endregion
-
-    // region withoutHttps
-
-    @Test
-    fun `withoutHttps removes https scheme`() {
-        assertEquals("example.com", "https://example.com".withoutHttps())
-    }
-
-    @Test
-    fun `withoutHttps removes http scheme`() {
-        assertEquals("example.com", "http://example.com".withoutHttps())
-    }
-
-    @Test
-    fun `withoutHttps removes trailing slash`() {
-        assertEquals("example.com", "https://example.com/".withoutHttps())
-    }
-
-    @Test
-    fun `withoutHttps leaves plain domain unchanged`() {
-        assertEquals("example.com", "example.com".withoutHttps())
-    }
-
-    @Test
-    fun `withoutHttps strips https then http from doubly-prefixed input`() {
-        // removePrefix("https://") → "http://example.com", then removePrefix("http://") → "example.com"
-        assertEquals("example.com", "https://http://example.com".withoutHttps())
-    }
-
-    // endregion
-
-    // region urlEncodeAmpersand
-
-    @Test
-    fun `urlEncodeAmpersand replaces single ampersand`() {
-        assertEquals("a%26b", "a&b".urlEncodeAmpersand())
-    }
-
-    @Test
-    fun `urlEncodeAmpersand replaces multiple ampersands`() {
-        assertEquals("a%26b%26c", "a&b&c".urlEncodeAmpersand())
-    }
-
-    @Test
-    fun `urlEncodeAmpersand leaves string without ampersand unchanged`() {
-        assertEquals("hello", "hello".urlEncodeAmpersand())
-    }
-
-    // endregion
-
-    // region urlEncode
-
-    @Test
-    fun `urlEncode encodes space as plus`() {
-        assertEquals("hello+world", "hello world".urlEncode())
-    }
-
-    @Test
-    fun `urlEncode encodes special characters`() {
-        assertEquals("a%26b", "a&b".urlEncode())
-    }
-
-    @Test
-    fun `urlEncode leaves alphanumeric unchanged`() {
-        assertEquals("abc123", "abc123".urlEncode())
-    }
-
-    // endregion
-}
+})

--- a/lib/src/test/java/de/lemke/commonutils/data/DelegatesAdvancedTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/DelegatesAdvancedTest.kt
@@ -16,35 +16,37 @@
 package de.lemke.commonutils.data
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
 import de.lemke.commonutils.SaveLocation
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class DelegatesAdvancedTest {
-    private lateinit var prefs: android.content.SharedPreferences
+    private lateinit var prefs: SharedPreferences
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
         prefs = ctx.getSharedPreferences("test_prefs", Context.MODE_PRIVATE)
         prefs.edit().clear().apply()
     }
 
-    // region boolean
-
     @Test
     fun `boolean returns default when key absent`() {
         class Holder {
             var flag: Boolean by prefs.delegates.boolean(default = true)
         }
-        assertThat(Holder().flag).isTrue()
+        Holder().flag.shouldBeTrue()
     }
 
     @Test
@@ -54,19 +56,15 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.flag = true
-        assertThat(Holder().flag).isTrue()
+        Holder().flag.shouldBeTrue()
     }
-
-    // endregion
-
-    // region int
 
     @Test
     fun `int returns default when key absent`() {
         class Holder {
             var n: Int by prefs.delegates.int(default = 42)
         }
-        assertThat(Holder().n).isEqualTo(42)
+        Holder().n shouldBe 42
     }
 
     @Test
@@ -76,19 +74,15 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.n = 99
-        assertThat(Holder().n).isEqualTo(99)
+        Holder().n shouldBe 99
     }
-
-    // endregion
-
-    // region float
 
     @Test
     fun `float returns default when key absent`() {
         class Holder {
             var f: Float by prefs.delegates.float(default = 3.14f)
         }
-        assertThat(Holder().f).isEqualTo(3.14f)
+        Holder().f shouldBe 3.14f
     }
 
     @Test
@@ -98,19 +92,15 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.f = 2.71f
-        assertThat(Holder().f).isEqualTo(2.71f)
+        Holder().f shouldBe 2.71f
     }
-
-    // endregion
-
-    // region long
 
     @Test
     fun `long returns default when key absent`() {
         class Holder {
             var l: Long by prefs.delegates.long(default = 100L)
         }
-        assertThat(Holder().l).isEqualTo(100L)
+        Holder().l shouldBe 100L
     }
 
     @Test
@@ -120,19 +110,15 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.l = Long.MAX_VALUE
-        assertThat(Holder().l).isEqualTo(Long.MAX_VALUE)
+        Holder().l shouldBe Long.MAX_VALUE
     }
-
-    // endregion
-
-    // region string
 
     @Test
     fun `string returns default when key absent`() {
         class Holder {
             var s: String by prefs.delegates.string(default = "hello")
         }
-        assertThat(Holder().s).isEqualTo("hello")
+        Holder().s shouldBe "hello"
     }
 
     @Test
@@ -142,19 +128,15 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.s = "world"
-        assertThat(Holder().s).isEqualTo("world")
+        Holder().s shouldBe "world"
     }
-
-    // endregion
-
-    // region stringSet
 
     @Test
     fun `stringSet returns default when key absent`() {
         class Holder {
             var ss: Set<String> by prefs.delegates.stringSet(default = setOf("a", "b"))
         }
-        assertThat(Holder().ss).containsExactly("a", "b")
+        Holder().ss shouldContainExactlyInAnyOrder setOf("a", "b")
     }
 
     @Test
@@ -164,19 +146,15 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.ss = setOf("x", "y", "z")
-        assertThat(Holder().ss).containsExactly("x", "y", "z")
+        Holder().ss shouldContainExactlyInAnyOrder setOf("x", "y", "z")
     }
-
-    // endregion
-
-    // region darkMode
 
     @Test
     fun `darkMode returns default false when key absent`() {
         class Holder {
             var dm: Boolean by prefs.delegates.darkMode(default = false)
         }
-        assertThat(Holder().dm).isFalse()
+        Holder().dm.shouldBeFalse()
     }
 
     @Test
@@ -186,9 +164,8 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.dm = true
-        assertThat(Holder().dm).isTrue()
-        // Verify stored as "1"
-        assertThat(prefs.getString("dm", null)).isEqualTo("1")
+        Holder().dm.shouldBeTrue()
+        prefs.getString("dm", null) shouldBe "1"
     }
 
     @Test
@@ -198,20 +175,16 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.dm = false
-        assertThat(Holder().dm).isFalse()
-        assertThat(prefs.getString("dm", null)).isEqualTo("0")
+        Holder().dm.shouldBeFalse()
+        prefs.getString("dm", null) shouldBe "0"
     }
-
-    // endregion
-
-    // region saveLocation
 
     @Test
     fun `saveLocation returns default when key absent`() {
         class Holder {
             var loc: SaveLocation by prefs.delegates.saveLocation(default = SaveLocation.PICTURES)
         }
-        assertThat(Holder().loc).isEqualTo(SaveLocation.PICTURES)
+        Holder().loc shouldBe SaveLocation.PICTURES
     }
 
     @Test
@@ -221,7 +194,7 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.loc = SaveLocation.DOWNLOADS
-        assertThat(Holder().loc).isEqualTo(SaveLocation.DOWNLOADS)
+        Holder().loc shouldBe SaveLocation.DOWNLOADS
     }
 
     @Test
@@ -231,12 +204,8 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.loc = SaveLocation.DCIM
-        assertThat(prefs.getString("loc", null)).isEqualTo("DCIM")
+        prefs.getString("loc", null) shouldBe "DCIM"
     }
-
-    // endregion
-
-    // region custom key
 
     @Test
     fun `boolean with explicit key uses that key in prefs`() {
@@ -245,8 +214,6 @@ class DelegatesAdvancedTest {
         }
         val h = Holder()
         h.flag = true
-        assertThat(prefs.getBoolean("my_custom_key", false)).isTrue()
+        prefs.getBoolean("my_custom_key", false) shouldBe true
     }
-
-    // endregion
 }

--- a/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/data/SettingsRepositoryTest.kt
@@ -18,21 +18,26 @@ package de.lemke.commonutils.data
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
 import de.lemke.commonutils.SaveLocation
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeEmpty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class SettingsRepositoryTest {
     private lateinit var prefs: SharedPreferences
     private lateinit var repo: SettingsRepository
 
-    @Before
+    private fun reload() = SettingsRepository(prefs)
+
+    @BeforeEach
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
         prefs = ctx.getSharedPreferences("settings_test", Context.MODE_PRIVATE)
@@ -40,93 +45,91 @@ class SettingsRepositoryTest {
         repo = SettingsRepository(prefs)
     }
 
-    private fun reload() = SettingsRepository(prefs)
-
     @Test
     fun `darkMode defaults to false`() {
-        assertThat(repo.darkMode).isFalse()
+        repo.darkMode.shouldBeFalse()
     }
 
     @Test
     fun `autoDarkMode defaults to true`() {
-        assertThat(repo.autoDarkMode).isTrue()
+        repo.autoDarkMode.shouldBeTrue()
     }
 
     @Test
     fun `lastVersionCode defaults to -1`() {
-        assertThat(repo.lastVersionCode).isEqualTo(-1)
+        repo.lastVersionCode shouldBe -1
     }
 
     @Test
     fun `lastVersionName defaults to 0_0_0`() {
-        assertThat(repo.lastVersionName).isEqualTo("0.0.0")
+        repo.lastVersionName shouldBe "0.0.0"
     }
 
     @Test
     fun `acceptedTosVersion defaults to -1`() {
-        assertThat(repo.acceptedTosVersion).isEqualTo(-1)
+        repo.acceptedTosVersion shouldBe -1
     }
 
     @Test
     fun `devModeEnabled defaults to false`() {
-        assertThat(repo.devModeEnabled).isFalse()
+        repo.devModeEnabled.shouldBeFalse()
     }
 
     @Test
     fun `search defaults to empty string`() {
-        assertThat(repo.search).isEmpty()
+        repo.search.shouldBeEmpty()
     }
 
     @Test
     fun `imageSaveLocation defaults to SaveLocation default`() {
-        assertThat(repo.imageSaveLocation).isEqualTo(SaveLocation.default)
+        repo.imageSaveLocation shouldBe SaveLocation.default
     }
 
     @Test
     fun `lastVersionCode round-trips written value`() {
         repo.lastVersionCode = 42
-        assertThat(reload().lastVersionCode).isEqualTo(42)
+        reload().lastVersionCode shouldBe 42
     }
 
     @Test
     fun `darkMode round-trips written value`() {
         repo.darkMode = true
-        assertThat(reload().darkMode).isTrue()
+        reload().darkMode.shouldBeTrue()
     }
 
     @Test
     fun `search round-trips written value`() {
         repo.search = "hello"
-        assertThat(reload().search).isEqualTo("hello")
+        reload().search shouldBe "hello"
     }
 
     @Test
     fun `imageSaveLocation round-trips DOWNLOADS`() {
         repo.imageSaveLocation = SaveLocation.DOWNLOADS
-        assertThat(reload().imageSaveLocation).isEqualTo(SaveLocation.DOWNLOADS)
+        reload().imageSaveLocation shouldBe SaveLocation.DOWNLOADS
     }
 
     @Test
     fun `autoDarkMode round-trips false`() {
         repo.autoDarkMode = false
-        assertThat(reload().autoDarkMode).isFalse()
+        reload().autoDarkMode.shouldBeFalse()
     }
 
     @Test
     fun `devModeEnabled round-trips true`() {
         repo.devModeEnabled = true
-        assertThat(reload().devModeEnabled).isTrue()
+        reload().devModeEnabled.shouldBeTrue()
     }
 
     @Test
     fun `acceptedTosVersion round-trips written value`() {
         repo.acceptedTosVersion = 3
-        assertThat(reload().acceptedTosVersion).isEqualTo(3)
+        reload().acceptedTosVersion shouldBe 3
     }
 
     @Test
     fun `lastVersionName round-trips written value`() {
         repo.lastVersionName = "2.5.0"
-        assertThat(reload().lastVersionName).isEqualTo("2.5.0")
+        reload().lastVersionName shouldBe "2.5.0"
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/di/CoroutineDispatchersModuleTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/di/CoroutineDispatchersModuleTest.kt
@@ -15,26 +15,21 @@
  */
 package de.lemke.commonutils.di
 
-import de.lemke.commonutils.MainDispatcherExtension
+import de.lemke.commonutils.MainDispatcherListener
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import kotlinx.coroutines.Dispatchers
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(MainDispatcherExtension::class)
-class CoroutineDispatchersModuleTest {
-    @Test
-    fun `provideIo returns Dispatchers IO`() {
-        assertSame(Dispatchers.IO, CoroutineDispatchersModule.provideIo())
-    }
+class CoroutineDispatchersModuleTest : ShouldSpec({
+    extensions(MainDispatcherListener())
 
-    @Test
-    fun `provideDefault returns Dispatchers Default`() {
-        assertSame(Dispatchers.Default, CoroutineDispatchersModule.provideDefault())
+    should("provideIo return Dispatchers.IO") {
+        CoroutineDispatchersModule.provideIo() shouldBeSameInstanceAs Dispatchers.IO
     }
-
-    @Test
-    fun `provideMain returns Dispatchers Main`() {
-        assertSame(Dispatchers.Main, CoroutineDispatchersModule.provideMain())
+    should("provideDefault return Dispatchers.Default") {
+        CoroutineDispatchersModule.provideDefault() shouldBeSameInstanceAs Dispatchers.Default
     }
-}
+    should("provideMain return Dispatchers.Main") {
+        CoroutineDispatchersModule.provideMain() shouldBeSameInstanceAs Dispatchers.Main
+    }
+})

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/DimmingViewTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/DimmingViewTest.kt
@@ -19,43 +19,41 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class DimmingViewTest {
     @Test
     fun `default constructor sets MATCH_PARENT layout params`() {
         val view = DimmingView(ApplicationProvider.getApplicationContext())
-        assertThat(view.layoutParams.width).isEqualTo(MATCH_PARENT)
-        assertThat(view.layoutParams.height).isEqualTo(MATCH_PARENT)
+        view.layoutParams.width shouldBe MATCH_PARENT
+        view.layoutParams.height shouldBe MATCH_PARENT
     }
 
     @Test
     fun `default constructor is not clickable`() {
-        val view = DimmingView(ApplicationProvider.getApplicationContext())
-        assertThat(view.isClickable).isFalse()
+        DimmingView(ApplicationProvider.getApplicationContext()).isClickable shouldBe false
     }
 
     @Test
     fun `default constructor is not focusable`() {
-        val view = DimmingView(ApplicationProvider.getApplicationContext())
-        assertThat(view.isFocusable).isFalse()
+        DimmingView(ApplicationProvider.getApplicationContext()).isFocusable shouldBe false
     }
 
     @Test
     fun `default constructor sets semi-transparent black background`() {
         val view = DimmingView(ApplicationProvider.getApplicationContext())
-        val bg = view.background as? ColorDrawable
-        assertThat(bg).isNotNull()
+        val bg = (view.background as? ColorDrawable).shouldNotBeNull()
         // Color.argb(0.5f, 0f, 0f, 0f): alpha = round(0.5 * 255 + 0.5) = 128
-        assertThat(Color.alpha(bg!!.color)).isEqualTo(128)
-        assertThat(Color.red(bg.color)).isEqualTo(0)
-        assertThat(Color.green(bg.color)).isEqualTo(0)
-        assertThat(Color.blue(bg.color)).isEqualTo(0)
+        Color.alpha(bg.color) shouldBe 128
+        Color.red(bg.color) shouldBe 0
+        Color.green(bg.color) shouldBe 0
+        Color.blue(bg.color) shouldBe 0
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/InfoBottomSheetTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/InfoBottomSheetTest.kt
@@ -17,13 +17,13 @@ package de.lemke.commonutils.ui.widget
 
 import android.view.Gravity.CENTER
 import android.view.Gravity.START
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class InfoBottomSheetTest {
     // newInstance is private on the companion object; access via reflection so tests
@@ -47,24 +47,24 @@ class InfoBottomSheetTest {
     @Test
     fun `title is stored in arguments bundle`() {
         val frag = newInstance("Hello", "World")
-        assertThat(frag.arguments!!.getString(InfoBottomSheet.KEY_TITLE)).isEqualTo("Hello")
+        frag.arguments!!.getString(InfoBottomSheet.KEY_TITLE) shouldBe "Hello"
     }
 
     @Test
     fun `message is stored in arguments bundle`() {
         val frag = newInstance("T", "My Message")
-        assertThat(frag.arguments!!.getString(InfoBottomSheet.KEY_MESSAGE)).isEqualTo("My Message")
+        frag.arguments!!.getString(InfoBottomSheet.KEY_MESSAGE) shouldBe "My Message"
     }
 
     @Test
     fun `text gravity defaults to CENTER`() {
         val frag = newInstance("T", "M")
-        assertThat(frag.arguments!!.getInt(InfoBottomSheet.KEY_TEXT_GRAVITY)).isEqualTo(CENTER)
+        frag.arguments!!.getInt(InfoBottomSheet.KEY_TEXT_GRAVITY) shouldBe CENTER
     }
 
     @Test
     fun `explicit text gravity is preserved`() {
         val frag = newInstance("T", "M", START)
-        assertThat(frag.arguments!!.getInt(InfoBottomSheet.KEY_TEXT_GRAVITY)).isEqualTo(START)
+        frag.arguments!!.getInt(InfoBottomSheet.KEY_TEXT_GRAVITY) shouldBe START
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/NoEntryViewTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/NoEntryViewTest.kt
@@ -18,20 +18,20 @@ package de.lemke.commonutils.ui.widget
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class NoEntryViewTest {
     private fun view() = NoEntryView(ApplicationProvider.getApplicationContext())
 
     @Test
     fun `initially hidden`() {
-        assertThat(view().isVisible).isFalse()
+        view().isVisible shouldBe false
     }
 
     @Test
@@ -39,28 +39,28 @@ class NoEntryViewTest {
         val v = view()
         v.updateVisibility(true)
         v.hide()
-        assertThat(v.isVisible).isFalse()
+        v.isVisible shouldBe false
     }
 
     @Test
     fun `updateVisibility false keeps view hidden`() {
         val v = view()
         v.updateVisibility(false)
-        assertThat(v.isVisible).isFalse()
+        v.isVisible shouldBe false
     }
 
     @Test
     fun `updateVisibility true shows view`() {
         val v = view()
         v.updateVisibility(true)
-        assertThat(v.isVisible).isTrue()
+        v.isVisible shouldBe true
     }
 
     @Test
     fun `updateVisibilityWith empty list shows view`() {
         val v = view()
         v.updateVisibilityWith(emptyList<String>())
-        assertThat(v.isVisible).isTrue()
+        v.isVisible shouldBe true
     }
 
     @Test
@@ -68,14 +68,14 @@ class NoEntryViewTest {
         val v = view()
         v.updateVisibility(true)
         v.updateVisibilityWith(listOf("item"))
-        assertThat(v.isVisible).isFalse()
+        v.isVisible shouldBe false
     }
 
     @Test
     fun `toggle shows hidden view`() {
-        val v = view() // starts hidden
+        val v = view()
         v.toggle()
-        assertThat(v.isVisible).isTrue()
+        v.isVisible shouldBe true
     }
 
     @Test
@@ -83,14 +83,14 @@ class NoEntryViewTest {
         val v = view()
         v.updateVisibility(true)
         v.toggle()
-        assertThat(v.isVisible).isFalse()
+        v.isVisible shouldBe false
     }
 
     @Test
     fun `text property round-trips`() {
         val v = view()
         v.text = "No results found"
-        assertThat(v.text).isEqualTo("No results found")
+        v.text shouldBe "No results found"
     }
 
     @Test
@@ -98,8 +98,8 @@ class NoEntryViewTest {
         val v = view()
         val other = View(ApplicationProvider.getApplicationContext()).also { it.isVisible = true }
         v.updateVisibility(true, other)
-        assertThat(v.isVisible).isTrue()
-        assertThat(other.isVisible).isFalse()
+        v.isVisible shouldBe true
+        other.isVisible shouldBe false
     }
 
     @Test
@@ -108,7 +108,7 @@ class NoEntryViewTest {
         val other = View(ApplicationProvider.getApplicationContext()).also { it.isVisible = false }
         v.updateVisibility(true)
         v.updateVisibility(false, other)
-        assertThat(v.isVisible).isFalse()
-        assertThat(other.isVisible).isTrue()
+        v.isVisible shouldBe false
+        other.isVisible shouldBe true
     }
 }

--- a/lib/src/test/java/de/lemke/commonutils/ui/widget/TouchBlockingViewTest.kt
+++ b/lib/src/test/java/de/lemke/commonutils/ui/widget/TouchBlockingViewTest.kt
@@ -17,37 +17,35 @@ package de.lemke.commonutils.ui.widget
 
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 @Config(sdk = [36])
 class TouchBlockingViewTest {
     @Test
     fun `clickable by default`() {
-        val view = TouchBlockingView(ApplicationProvider.getApplicationContext())
-        assertThat(view.isClickable).isTrue()
+        TouchBlockingView(ApplicationProvider.getApplicationContext()).isClickable shouldBe true
     }
 
     @Test
     fun `focusable by default`() {
-        val view = TouchBlockingView(ApplicationProvider.getApplicationContext())
-        assertThat(view.isFocusable).isTrue()
+        TouchBlockingView(ApplicationProvider.getApplicationContext()).isFocusable shouldBe true
     }
 
     @Test
     fun `inherits MATCH_PARENT layout params from DimmingView`() {
         val view = TouchBlockingView(ApplicationProvider.getApplicationContext())
-        assertThat(view.layoutParams.width).isEqualTo(MATCH_PARENT)
-        assertThat(view.layoutParams.height).isEqualTo(MATCH_PARENT)
+        view.layoutParams.width shouldBe MATCH_PARENT
+        view.layoutParams.height shouldBe MATCH_PARENT
     }
 
     @Test
     fun `is a DimmingView`() {
-        val view = TouchBlockingView(ApplicationProvider.getApplicationContext())
-        assertThat(view).isInstanceOf(DimmingView::class.java)
+        TouchBlockingView(ApplicationProvider.getApplicationContext()).shouldBeInstanceOf<DimmingView>()
     }
 }


### PR DESCRIPTION
## Summary

- **Kotest 6.1.11** replaces Truth assertions across all tests; `kotest-runner-junit5` drives JUnit5 discovery
- **Pure-JVM tests** (`URLUtils`, `CheckAppStart`, `ExportUtils`, `SaveLocation`, `BasicUtils`, `Architecture`, `CoroutineDispatchersModule`) migrated to `ShouldSpec` with Kotest matchers
- **Robolectric tests** (`NoEntryView`, `TouchBlockingView`, `DimmingView`, `InfoBottomSheet`, `SaveLocationRobolectric`, `DelegatesAdvanced`, `SettingsRepository`) converted to plain JUnit5 `@Test` + Kotest assertions — Kotest spec lifecycle is incompatible with `RobolectricExtension` ordering, so `@ExtendWith(RobolectricExtension::class)` on plain JUnit5 classes is the correct pattern
- **`MainDispatcherExtension` → `MainDispatcherListener`** — updated to Kotest 6 `BeforeTestListener`/`AfterTestListener` interfaces; `TestResult` moved to `io.kotest.engine.test`
- **New `CoroutineContractsTest`** (Turbine, `ShouldSpec`) pins `StateFlow`/`Channel` collection invariants
- **New `LifecycleCollectorsTest`** (`Robolectric` SDK 34) covers `collectState`/`collectEvents` activity extensions; uses a single `@Test` method due to `robolectric-extension 0.9.0` one-sandbox-per-class limitation
- **`junit.platform.launcher.interceptors.enabled=true`** JVM arg added — required to activate the `LauncherInterceptor` SPI that bootstraps Robolectric

## Test Plan

- [x] `./gradlew testDebugUnitTest` — 132 tests, 0 failures
- [x] `./gradlew koverVerify` — coverage ≥ 12% floor passes
- [x] `./gradlew spotlessCheck` — no formatting violations
- [x] `./gradlew detekt` — no static analysis issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated test suite from JUnit/Truth to Kotest and updated build configuration to use JUnit 5 platform and Kotest libraries.
  * Adjusted test runtime integration for Robolectric and coroutine dispatcher handling.
* **Tests**
  * Rewrote many tests to Kotest style, added new coroutine/lifecycle contract tests, and included a test Android manifest for instrumentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lemkinator/common-utils/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->